### PR TITLE
chore: retire manu-orch as standalone service

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -1,6 +1,6 @@
 ---
-description: Python standards for manu-eye and manu-orch services
-globs: manu-eye/**/*.py,manu-orch/**/*.py
+description: Python standards for manu-eye service
+globs: manu-eye/**/*.py
 alwaysApply: false
 ---
 
@@ -23,36 +23,6 @@ alwaysApply: false
 - Prefer `dataclasses` or Pydantic `BaseModel` for structured data
 - No mutable default arguments
 
-## Architecture (FastAPI — manu-orch)
-
-Feature-based folder structure:
-
-```
-src/
-  features/
-    orders/
-      router.py
-      service.py
-      schemas.py
-      models.py
-    events/
-      router.py
-      service.py
-      schemas.py
-      models.py
-  shared/
-    errors.py
-    dependencies.py
-  db.py
-  config.py
-  main.py
-```
-
-- Routers handle HTTP, services handle logic
-- Pydantic schemas for request/response validation (OpenAPI auto-generated)
-- SQLAlchemy models for DB, Pydantic schemas for API — never mix them
-- Use FastAPI `Depends()` for dependency injection
-
 ## Architecture (manu-eye)
 
 Flat structure until complexity demands otherwise:
@@ -61,7 +31,7 @@ Flat structure until complexity demands otherwise:
 src/
   camera.py       # OpenCV capture loop
   decoder.py      # QR decode + dedup
-  client.py       # HTTP client to manu-orch
+  client.py       # HTTP client to manu-gen backend
   config.py       # env vars / settings
   main.py         # entry point
 ```

--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -39,21 +39,16 @@ src/
 ## Error Handling
 
 - Define custom exception classes inheriting from a base `AppError`
-- Use FastAPI exception handlers for consistent API responses
 - Never use bare `except:` — always catch specific exceptions
 - Log errors with context using `structlog` or stdlib `logging`
 
 ## Async
 
-- Use `async def` for I/O-bound operations in FastAPI
-- Use `httpx.AsyncClient` for outbound HTTP calls
+- Use `httpx.AsyncClient` for outbound HTTP calls to manu-gen backend
 - Use `asyncio.gather()` for independent concurrent operations
-- Never mix sync and async without `run_in_executor`
 
 ## Testing
 
-- Use `pytest` with `pytest-asyncio` for async tests
+- Use `pytest` for tests
 - Name tests: `test_should_[behaviour]_when_[condition]`
-- Use `httpx.ASGITransport` for integration tests against FastAPI
-- Fixtures for DB sessions — always rollback after each test
 - Arrange-Act-Assert structure

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Ceramic order tracking system — QR labels on trays, cameras at stations, live 
 
 | Service | Description | Tech |
 |---------|-------------|------|
-| **manu-gen** | QR label creator — order form + thermal print | React + Node.js |
+| **manu-gen** | QR label creator — order form, QR generation, event tracking, dashboard | React + Node.js |
 | **manu-eye** | Camera station — reads QR codes, sends events | Python + OpenCV |
-| **manu-orch** | Orchestrator — collects events, serves status | Python + FastAPI |
+
+> Event ingestion and analytics will be added to manu-gen when manu-eye is ready.
 
 ## Getting Started
 
@@ -26,10 +27,8 @@ cd manu-gen/frontend && yarn install && yarn dev
  React form  ──> Node API      Camera ──> Python QR reader
                   │                           │
                   │         POST /events      │
-                  ▼              ◄─────────────┘
-              [manu-orch]
-               FastAPI ──> SQLite
+                  ◄───────────────────────────┘
                   │
                   ▼
-              Dashboard
+               SQLite ──> Dashboard
 ```


### PR DESCRIPTION
## Summary
Removes manu-orch as a separate service. Event tracking and analytics will be added as feature modules inside manu-gen when manu-eye is ready.

## Description
The original architecture had three services: manu-gen, manu-eye, and manu-orch. After discussion, we decided a separate orchestrator adds unnecessary complexity for the POC — one backend (manu-gen) handling both orders and future event ingestion is simpler to deploy and maintain on a single workshop laptop.

### What changed
- Deleted `manu-orch/.gitkeep` placeholder
- Updated `README.md` — removed manu-orch from components table, updated architecture diagram to show manu-eye posting directly to manu-gen
- Updated `.cursor/rules/python.mdc` — scoped globs to `manu-eye/**/*.py` only, removed FastAPI/manu-orch architecture section and references

## Test plan
- [x] Verify `manu-orch/` directory no longer exists
- [x] Verify README reflects two-component architecture
- [x] Verify python rule only targets manu-eye

## Notes
No code changes to manu-gen backend or frontend. This is purely cleanup.

Made with [Cursor](https://cursor.com)