### PR TITLE
feat(infra): add docker-compose for local dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,41 @@ Ceramic order tracking system — QR labels on trays, cameras at stations, live 
 
 ## Getting Started
 
-Each service has its own README with setup instructions. Start with `manu-gen`:
+### Option A — Docker (recommended)
+
+Requires Docker Engine and Docker Compose. On macOS with [Colima](https://github.com/abiosoft/colima):
+
+```bash
+brew install docker docker-compose colima
+colima start
+```
+
+Then run everything with a single command:
+
+```bash
+docker-compose up --build
+```
+
+| Service  | URL                    |
+|----------|------------------------|
+| Frontend | http://localhost:5173  |
+| Backend  | http://localhost:3000  |
+
+Source files are bind-mounted, so changes in `manu-gen/backend/src` and `manu-gen/frontend/src` trigger hot-reload automatically.
+
+To stop and remove containers:
+
+```bash
+docker-compose down
+```
+
+To also wipe the SQLite volume:
+
+```bash
+docker-compose down -v
+```
+
+### Option B — Local
 
 ```bash
 cd manu-gen/backend && yarn install && yarn dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  backend:
+    build:
+      context: manu-gen/backend
+    init: true
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      PORT: 3000
+      DB_PATH: /data/manu-gen.db
+      CORS_ORIGIN: http://localhost:5173
+    volumes:
+      - backend-data:/data
+      - ./manu-gen/backend/src:/app/src
+      - /app/node_modules
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(r=>{if(!r.ok)throw new Error('status '+r.status);return r.json()}).then(d=>console.log('ok',JSON.stringify(d))).catch(e=>{console.error(e.message);process.exit(1)})"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
+
+  frontend:
+    build:
+      context: manu-gen/frontend
+    init: true
+    restart: unless-stopped
+    ports:
+      - "5173:5173"
+    environment:
+      API_TARGET: http://backend:3000
+    volumes:
+      - ./manu-gen/frontend/src:/app/src
+      - /app/node_modules
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:5173').then(r=>{if(!r.ok)throw new Error('status '+r.status)}).catch(e=>{console.error(e.message);process.exit(1)})"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 20s
+
+volumes:
+  backend-data:

--- a/manu-gen/backend/.dockerignore
+++ b/manu-gen/backend/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+.yarn
+*.db
+*.db-shm
+*.db-wal
+.env
+.env.local
+.git
+*.md
+*.test.ts

--- a/manu-gen/backend/Dockerfile
+++ b/manu-gen/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:24.14.0-slim
+
+WORKDIR /app
+
+COPY .yarnrc.yml package.json yarn.lock ./
+RUN corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install
+
+COPY tsconfig.json ./
+COPY src/ src/
+
+EXPOSE 3000
+
+CMD ["yarn", "dev"]

--- a/manu-gen/frontend/.dockerignore
+++ b/manu-gen/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.yarn
+.env
+.env.local
+.git
+*.md
+*.test.ts
+*.test.tsx
+src/test-setup.ts

--- a/manu-gen/frontend/Dockerfile
+++ b/manu-gen/frontend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:24.14.0-slim
+
+WORKDIR /app
+
+COPY .yarnrc.yml package.json yarn.lock ./
+RUN corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install
+
+COPY tsconfig*.json vite.config.ts index.html ./
+COPY public/ public/
+COPY src/ src/
+
+EXPOSE 5173
+
+CMD ["yarn", "dev", "--host"]

--- a/manu-gen/frontend/vite.config.ts
+++ b/manu-gen/frontend/vite.config.ts
@@ -4,12 +4,14 @@ import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
+const API_TARGET = process.env.API_TARGET ?? "http://localhost:3000";
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {
       "/orders": {
-        target: "http://localhost:3000",
+        target: API_TARGET,
         configure: (proxy) => {
           proxy.on("proxyReq", (_, req) => {
             console.log(`[proxy] → ${req.method} ${req.url}`);


### PR DESCRIPTION
## Summary
- Add Docker Compose setup so both frontend and backend start with a single command, replacing the need to run `yarn dev` in two separate terminals.

## Changes
- **`docker-compose.yml`** — orchestrates backend (port 3000) and frontend (port 5173) with health checks, signal forwarding (`init: true`), restart policy, and a named volume for SQLite persistence
- **`manu-gen/backend/Dockerfile`** — Node 24 slim image, Yarn 4 via corepack, runs `tsx watch` for hot-reload
- **`manu-gen/frontend/Dockerfile`** — Node 24 slim image, Yarn 4 via corepack, runs `vite dev --host`
- **`manu-gen/frontend/vite.config.ts`** — proxy target is now configurable via `API_TARGET` env var (defaults to `http://localhost:3000` for local dev, set to `http://backend:3000` in Docker)
- **`.dockerignore`** files for both services to keep images lean
- **`README.md`** — added Docker getting-started instructions (Option A) with Colima setup

## Test plan
- [ ] Run `docker-compose up --build` — both containers start, backend health check passes, frontend becomes available
- [ ] Open http://localhost:5173 — frontend loads and can create/list orders
- [ ] Edit a file in `manu-gen/backend/src/` — tsx watch restarts automatically
- [ ] Edit a file in `manu-gen/frontend/src/` — Vite HMR updates the browser
- [ ] Run `docker-compose down` — containers stop cleanly (graceful shutdown via tini)
- [ ] Verify local dev still works: `cd manu-gen/frontend && yarn dev` proxies to `localhost:3000` as before

## Notes
- Colima + `docker-compose` (standalone binary) is the recommended free Docker setup for macOS
- `yarn install` runs without `--immutable` in Dockerfiles because the lockfile may need platform-specific resolution inside the Linux container; CI enforces lockfile integrity separately

Made with [Cursor](https://cursor.com)