### PR TITLE
feat(stations): add station dashboard UI with sidebar navigation

### DIFF
--- a/manu-gen/backend/src/features/stations/stations.controller.test.ts
+++ b/manu-gen/backend/src/features/stations/stations.controller.test.ts
@@ -121,3 +121,66 @@ describe("PUT /stations/:id/eye", () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe("DELETE /stations/:id/eye", () => {
+  it("should unassign the eye and return the station", async () => {
+    const createRes = await request(app).post("/stations").send({ name: "Casting" });
+    const id = createRes.body.id;
+    await request(app).put(`/stations/${id}/eye`).send({ eyeId: "eye-1" });
+
+    const res = await request(app).delete(`/stations/${id}/eye`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.eyeId).toBeNull();
+  });
+
+  it("should return 400 when station has no eye assigned", async () => {
+    const createRes = await request(app).post("/stations").send({ name: "Casting" });
+    const id = createRes.body.id;
+
+    const res = await request(app).delete(`/stations/${id}/eye`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("should return 404 when station does not exist", async () => {
+    const res = await request(app).delete("/stations/nonexistent/eye");
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /stations/:id", () => {
+  it("should delete a station and return 204", async () => {
+    const createRes = await request(app).post("/stations").send({ name: "Casting" });
+    const id = createRes.body.id;
+
+    const res = await request(app).delete(`/stations/${id}`);
+
+    expect(res.status).toBe(204);
+
+    const getRes = await request(app).get(`/stations/${id}`);
+    expect(getRes.status).toBe(404);
+  });
+
+  it("should cascade-delete station with tracking events", async () => {
+    const createRes = await request(app).post("/stations").send({ name: "Casting" });
+    const id = createRes.body.id;
+    db.prepare(
+      `INSERT INTO tracking_events (tray_code, station_id, eye_id, captured_at) VALUES (?, ?, ?, ?)`,
+    ).run("TRAY-001", id, "eye-1", "2025-01-01T00:00:00Z");
+
+    const res = await request(app).delete(`/stations/${id}`);
+
+    expect(res.status).toBe(204);
+
+    const getRes = await request(app).get(`/stations/${id}`);
+    expect(getRes.status).toBe(404);
+  });
+
+  it("should return 404 when station does not exist", async () => {
+    const res = await request(app).delete("/stations/nonexistent");
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/manu-gen/backend/src/features/stations/stations.controller.ts
+++ b/manu-gen/backend/src/features/stations/stations.controller.ts
@@ -74,3 +74,23 @@ stationsRouter.put("/:id/eye", (req, res, next) => {
     next(err);
   }
 });
+
+stationsRouter.delete("/:id/eye", (req, res, next) => {
+  try {
+    const id = parseStationId(req.params.id);
+    const station = stationsService.unassignEye(id);
+    res.json(station);
+  } catch (err) {
+    next(err);
+  }
+});
+
+stationsRouter.delete("/:id", (req, res, next) => {
+  try {
+    const id = parseStationId(req.params.id);
+    stationsService.deleteStation(id);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});

--- a/manu-gen/backend/src/features/stations/stations.service.test.ts
+++ b/manu-gen/backend/src/features/stations/stations.service.test.ts
@@ -88,6 +88,66 @@ describe("assignEye", () => {
   });
 });
 
+describe("unassignEye", () => {
+  it("should clear the eye from a station", () => {
+    const station = stationsService.createStation({ name: "Casting" });
+    stationsService.assignEye(station.id, { eyeId: "eye-1" });
+
+    const updated = stationsService.unassignEye(station.id);
+
+    expect(updated.eyeId).toBeNull();
+  });
+
+  it("should throw 400 when station has no eye assigned", () => {
+    const station = stationsService.createStation({ name: "Casting" });
+
+    expect(() => stationsService.unassignEye(station.id)).toThrow("no eye assigned");
+  });
+
+  it("should throw 404 when station does not exist", () => {
+    expect(() => stationsService.unassignEye("nonexistent")).toThrow("not found");
+  });
+});
+
+describe("deleteStation", () => {
+  it("should delete a station with no events", () => {
+    const station = stationsService.createStation({ name: "Casting" });
+
+    stationsService.deleteStation(station.id);
+
+    expect(() => stationsService.getStationById(station.id)).toThrow("not found");
+  });
+
+  it("should cascade-delete tracking events and the station", () => {
+    const station = stationsService.createStation({ name: "Casting" });
+    db.prepare(
+      `INSERT INTO tracking_events (tray_code, station_id, eye_id, captured_at) VALUES (?, ?, ?, ?)`,
+    ).run("TRAY-001", station.id, "eye-1", "2025-01-01T00:00:00Z");
+
+    stationsService.deleteStation(station.id);
+
+    expect(() => stationsService.getStationById(station.id)).toThrow("not found");
+    const eventCount = db.prepare(
+      "SELECT COUNT(*) AS cnt FROM tracking_events WHERE station_id = ?",
+    ).get(station.id) as { cnt: number };
+    expect(eventCount.cnt).toBe(0);
+  });
+
+  it("should unassign the eye before deleting", () => {
+    const station = stationsService.createStation({ name: "Casting" });
+    stationsService.assignEye(station.id, { eyeId: "eye-1" });
+
+    stationsService.deleteStation(station.id);
+
+    expect(() => stationsService.getStationById(station.id)).toThrow("not found");
+    expect(stationsService.getStationByEyeId("eye-1")).toBeNull();
+  });
+
+  it("should throw 404 when station does not exist", () => {
+    expect(() => stationsService.deleteStation("nonexistent")).toThrow("not found");
+  });
+});
+
 describe("getStationByEyeId", () => {
   it("should return the station assigned to the eye", () => {
     const station = stationsService.createStation({ name: "Polishing" });

--- a/manu-gen/backend/src/features/stations/stations.service.ts
+++ b/manu-gen/backend/src/features/stations/stations.service.ts
@@ -20,7 +20,15 @@ const stmtList = db.prepare(
 
 const stmtClearEye = db.prepare(`UPDATE stations SET eye_id = NULL WHERE eye_id = ?`);
 
+const stmtClearEyeById = db.prepare(`UPDATE stations SET eye_id = NULL WHERE id = ?`);
+
 const stmtAssignEye = db.prepare(`UPDATE stations SET eye_id = @eye_id WHERE id = @id`);
+
+const stmtDeleteStation = db.prepare(`DELETE FROM stations WHERE id = ?`);
+
+const stmtCountEventsByStation = db.prepare(
+  `SELECT COUNT(*) AS cnt FROM tracking_events WHERE station_id = ?`,
+);
 
 function generateId(): string {
   return `station-${crypto.randomUUID().slice(0, 8)}`;
@@ -62,4 +70,31 @@ const assignEyeTx = db.transaction((stationId: string, input: AssignEyeInput): v
 export function assignEye(stationId: string, input: AssignEyeInput): Station {
   assignEyeTx(stationId, input);
   return getStationById(stationId);
+}
+
+export function unassignEye(stationId: string): Station {
+  const station = getStationById(stationId);
+  if (station.eyeId === null) {
+    throw new AppError(400, `Station ${stationId} has no eye assigned`);
+  }
+  stmtClearEyeById.run(stationId);
+  return getStationById(stationId);
+}
+
+const stmtDeleteEventsByStation = db.prepare(
+  `DELETE FROM tracking_events WHERE station_id = ?`,
+);
+
+const deleteStationTx = db.transaction((stationId: string): void => {
+  const row = stmtGetById.get(stationId) as StationRow | undefined;
+  if (!row) {
+    throw new AppError(404, `Station with id ${stationId} not found`);
+  }
+  stmtClearEyeById.run(stationId);
+  stmtDeleteEventsByStation.run(stationId);
+  stmtDeleteStation.run(stationId);
+});
+
+export function deleteStation(stationId: string): void {
+  deleteStationTx(stationId);
 }

--- a/manu-gen/backend/src/features/stations/stations.service.ts
+++ b/manu-gen/backend/src/features/stations/stations.service.ts
@@ -26,10 +26,6 @@ const stmtAssignEye = db.prepare(`UPDATE stations SET eye_id = @eye_id WHERE id 
 
 const stmtDeleteStation = db.prepare(`DELETE FROM stations WHERE id = ?`);
 
-const stmtCountEventsByStation = db.prepare(
-  `SELECT COUNT(*) AS cnt FROM tracking_events WHERE station_id = ?`,
-);
-
 function generateId(): string {
   return `station-${crypto.randomUUID().slice(0, 8)}`;
 }

--- a/manu-gen/frontend/src/App.tsx
+++ b/manu-gen/frontend/src/App.tsx
@@ -1,46 +1,16 @@
 import { useState } from "react";
-import { OrderForm } from "./features/orders/components/OrderForm";
-import { QrPreview } from "./features/orders/components/QrPreview";
-import { OrderList } from "./features/orders/components/OrderList";
-import type { Order } from "./features/orders/orders.types";
+import { Layout } from "./shared/components/Layout";
+import type { PageId } from "./shared/components/Sidebar";
+import { OrdersPage } from "./features/orders/components/OrdersPage";
+import { StationsPage } from "./features/stations/components/StationsPage";
 
 export function App() {
-  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
+  const [currentPage, setCurrentPage] = useState<PageId>("orders");
 
   return (
-    <div className="min-h-screen bg-gray-50 p-6">
-      <header className="mb-8 print:hidden">
-        <h1 className="text-2xl font-bold text-gray-900">Manu Tracker</h1>
-        <p className="text-sm text-gray-500">Manufacturing order management</p>
-      </header>
-
-      <div className="mx-auto max-w-6xl">
-        <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2">
-          <div className="rounded-lg border bg-white p-6 shadow-sm print:hidden">
-            <OrderForm onOrderCreated={setSelectedOrder} />
-          </div>
-
-          <div
-            className={`rounded-lg border bg-white p-6 shadow-sm${selectedOrder === null ? " print:hidden" : ""}`}
-          >
-            {selectedOrder !== null ? (
-              <QrPreview order={selectedOrder} />
-            ) : (
-              <div className="flex h-full items-center justify-center text-sm text-gray-400">
-                Create an order to see the QR code
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="rounded-lg border bg-white p-6 shadow-sm print:hidden">
-          <h2 className="mb-4 text-lg font-semibold">Recent Orders</h2>
-          <OrderList
-            selectedOrderId={selectedOrder?.id ?? null}
-            onSelectOrder={setSelectedOrder}
-          />
-        </div>
-      </div>
-    </div>
+    <Layout currentPage={currentPage} onNavigate={setCurrentPage}>
+      {currentPage === "orders" && <OrdersPage />}
+      {currentPage === "stations" && <StationsPage />}
+    </Layout>
   );
 }

--- a/manu-gen/frontend/src/features/orders/components/OrdersPage.tsx
+++ b/manu-gen/frontend/src/features/orders/components/OrdersPage.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { OrderForm } from "./OrderForm";
+import { QrPreview } from "./QrPreview";
+import { OrderList } from "./OrderList";
+import type { Order } from "../orders.types";
+
+export function OrdersPage() {
+  const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <h2 className="mb-6 text-xl font-semibold text-gray-900 print:hidden">Orders</h2>
+
+      <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="rounded-lg border bg-white p-6 shadow-sm print:hidden">
+          <OrderForm onOrderCreated={setSelectedOrder} />
+        </div>
+
+        <div
+          className={`rounded-lg border bg-white p-6 shadow-sm${selectedOrder === null ? " print:hidden" : ""}`}
+        >
+          {selectedOrder !== null ? (
+            <QrPreview order={selectedOrder} />
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-gray-400">
+              Create an order to see the QR code
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-white p-6 shadow-sm print:hidden">
+        <h3 className="mb-4 text-lg font-semibold">Recent Orders</h3>
+        <OrderList
+          selectedOrderId={selectedOrder?.id ?? null}
+          onSelectOrder={setSelectedOrder}
+        />
+      </div>
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/features/stations/components/CreateStationForm.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/CreateStationForm.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { createWrapper } from "../../../test-utils";
+import { CreateStationForm } from "./CreateStationForm";
+
+vi.mock("../hooks/useCreateStation", () => ({
+  useCreateStation: vi.fn(),
+}));
+
+import { useCreateStation } from "../hooks/useCreateStation";
+
+describe("CreateStationForm", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should render name and location fields", () => {
+    vi.mocked(useCreateStation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCreateStation>);
+
+    render(<CreateStationForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Location/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create Station" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should show validation error when name is empty", async () => {
+    vi.mocked(useCreateStation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCreateStation>);
+
+    const user = userEvent.setup();
+    render(<CreateStationForm />, { wrapper: createWrapper() });
+
+    await user.click(screen.getByRole("button", { name: "Create Station" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Station name is required"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should call mutate with form values on valid submit", async () => {
+    const mutate = vi.fn();
+    vi.mocked(useCreateStation).mockReturnValue({
+      mutate,
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCreateStation>);
+
+    const user = userEvent.setup();
+    render(<CreateStationForm />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByLabelText("Name"), "Polishing");
+    await user.type(screen.getByLabelText(/Location/), "Floor 2");
+    await user.click(screen.getByRole("button", { name: "Create Station" }));
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith(
+        { name: "Polishing", location: "Floor 2" },
+        expect.any(Object),
+      );
+    });
+  });
+
+  it("should reset the form on successful creation", async () => {
+    const mutate = vi.fn().mockImplementation((_values, options) => {
+      options.onSuccess();
+    });
+    vi.mocked(useCreateStation).mockReturnValue({
+      mutate,
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCreateStation>);
+
+    const user = userEvent.setup();
+    render(<CreateStationForm />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByLabelText("Name"), "Polishing");
+    await user.click(screen.getByRole("button", { name: "Create Station" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toHaveValue("");
+    });
+  });
+
+  it("should display server error", () => {
+    vi.mocked(useCreateStation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      error: new Error("Duplicate name"),
+    } as unknown as ReturnType<typeof useCreateStation>);
+
+    render(<CreateStationForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("Error: Duplicate name")).toBeInTheDocument();
+  });
+
+  it("should disable button while pending", () => {
+    vi.mocked(useCreateStation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+      error: null,
+    } as unknown as ReturnType<typeof useCreateStation>);
+
+    render(<CreateStationForm />, { wrapper: createWrapper() });
+
+    expect(screen.getByRole("button", { name: "Creating..." })).toBeDisabled();
+  });
+});

--- a/manu-gen/frontend/src/features/stations/components/CreateStationForm.tsx
+++ b/manu-gen/frontend/src/features/stations/components/CreateStationForm.tsx
@@ -1,0 +1,71 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createStationSchema, type CreateStationFormValues } from "../stations.schema";
+import { useCreateStation } from "../hooks/useCreateStation";
+
+export function CreateStationForm() {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CreateStationFormValues>({
+    resolver: zodResolver(createStationSchema),
+  });
+
+  const { mutate, isPending, error } = useCreateStation();
+
+  function onSubmit(values: CreateStationFormValues) {
+    mutate(values, { onSuccess: () => reset() });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex flex-wrap items-end gap-3"
+    >
+      <div className="flex flex-col gap-1">
+        <label htmlFor="station-name" className="text-sm font-medium">
+          Name
+        </label>
+        <input
+          id="station-name"
+          {...register("name")}
+          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="e.g. Polishing"
+        />
+        <p className="min-h-4 text-xs text-red-600">
+          {errors.name?.message ?? "\u00A0"}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="station-location" className="text-sm font-medium">
+          Location <span className="text-gray-400">(optional)</span>
+        </label>
+        <input
+          id="station-location"
+          {...register("location")}
+          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="e.g. Floor 2"
+        />
+        <p className="min-h-4 text-xs">{"\u00A0"}</p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded border border-blue-600 bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:border-blue-700 hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isPending ? "Creating..." : "Create Station"}
+        </button>
+        <p className="min-h-4 text-xs">{"\u00A0"}</p>
+      </div>
+
+      {error && (
+        <p className="w-full text-sm text-red-600">Error: {error.message}</p>
+      )}
+    </form>
+  );
+}

--- a/manu-gen/frontend/src/features/stations/components/StationCard.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationCard.test.tsx
@@ -1,0 +1,230 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { createWrapper } from "../../../test-utils";
+import { StationCard } from "./StationCard";
+import type { Station } from "../stations.types";
+
+vi.mock("../hooks/useAssignEye", () => ({ useAssignEye: vi.fn() }));
+vi.mock("../hooks/useUnassignEye", () => ({ useUnassignEye: vi.fn() }));
+vi.mock("../hooks/useDeleteStation", () => ({ useDeleteStation: vi.fn() }));
+
+import { useAssignEye } from "../hooks/useAssignEye";
+import { useUnassignEye } from "../hooks/useUnassignEye";
+import { useDeleteStation } from "../hooks/useDeleteStation";
+
+const unassignedStation: Station = {
+  id: "station-aaa",
+  name: "Polishing",
+  location: "Floor 2",
+  eyeId: null,
+};
+
+const assignedStation: Station = {
+  id: "station-bbb",
+  name: "Casting",
+  location: "Floor 1",
+  eyeId: "eye-1",
+};
+
+function mockHooks(overrides?: {
+  assignEye?: Partial<ReturnType<typeof useAssignEye>>;
+  unassignEye?: Partial<ReturnType<typeof useUnassignEye>>;
+  deleteStation?: Partial<ReturnType<typeof useDeleteStation>>;
+}) {
+  vi.mocked(useAssignEye).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+    ...overrides?.assignEye,
+  } as unknown as ReturnType<typeof useAssignEye>);
+
+  vi.mocked(useUnassignEye).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+    ...overrides?.unassignEye,
+  } as unknown as ReturnType<typeof useUnassignEye>);
+
+  vi.mocked(useDeleteStation).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+    ...overrides?.deleteStation,
+  } as unknown as ReturnType<typeof useDeleteStation>);
+}
+
+describe("StationCard", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should render station name and location", () => {
+    mockHooks();
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("Polishing")).toBeInTheDocument();
+    expect(screen.getByText("Floor 2")).toBeInTheDocument();
+  });
+
+  it("should show assign form when no eye is assigned", () => {
+    mockHooks();
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(
+      screen.getByPlaceholderText("Enter eye ID (e.g. eye-1)"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Assign" })).toBeInTheDocument();
+  });
+
+  it("should show eye badge when eye is assigned", () => {
+    mockHooks();
+    render(<StationCard station={assignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("eye-1")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Unassign eye eye-1" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should call assignEye.mutate on assign form submit", async () => {
+    const mutate = vi.fn();
+    mockHooks({ assignEye: { mutate } });
+
+    const user = userEvent.setup();
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.type(
+      screen.getByPlaceholderText("Enter eye ID (e.g. eye-1)"),
+      "eye-42",
+    );
+    await user.click(screen.getByRole("button", { name: "Assign" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { stationId: "station-aaa", eyeId: "eye-42" },
+      expect.any(Object),
+    );
+  });
+
+  it("should disable assign button when input is empty", () => {
+    mockHooks();
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByRole("button", { name: "Assign" })).toBeDisabled();
+  });
+
+  it("should call unassignEye.mutate when unassign button is clicked", async () => {
+    const mutate = vi.fn();
+    mockHooks({ unassignEye: { mutate } });
+
+    const user = userEvent.setup();
+    render(<StationCard station={assignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Unassign eye eye-1" }),
+    );
+
+    expect(mutate).toHaveBeenCalledWith("station-bbb");
+  });
+
+  it("should require confirmation before deleting", async () => {
+    const mutate = vi.fn();
+    mockHooks({ deleteStation: { mutate } });
+
+    const user = userEvent.setup();
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete station Polishing" }),
+    );
+
+    expect(mutate).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("should call deleteStation.mutate on confirm", async () => {
+    const mutate = vi.fn();
+    mockHooks({ deleteStation: { mutate } });
+
+    const user = userEvent.setup();
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete station Polishing" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(mutate).toHaveBeenCalledWith("station-aaa", expect.any(Object));
+  });
+
+  it("should dismiss confirmation on cancel", async () => {
+    mockHooks();
+
+    const user = userEvent.setup();
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete station Polishing" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.getByRole("button", { name: "Delete station Polishing" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Confirm" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should reset confirmDelete on mutation error", async () => {
+    const mutate = vi.fn().mockImplementation((_id, options) => {
+      options.onError(new Error("Has events"));
+    });
+    mockHooks({ deleteStation: { mutate, error: new Error("Has events") } });
+
+    const user = userEvent.setup();
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete station Polishing" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Delete station Polishing" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should display mutation error message", () => {
+    mockHooks({ assignEye: { error: new Error("Eye already assigned") } });
+
+    render(<StationCard station={unassignedStation} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByText("Eye already assigned")).toBeInTheDocument();
+  });
+});

--- a/manu-gen/frontend/src/features/stations/components/StationCard.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationCard.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import type { Station } from "../stations.types";
+import { useAssignEye } from "../hooks/useAssignEye";
+import { useUnassignEye } from "../hooks/useUnassignEye";
+import { useDeleteStation } from "../hooks/useDeleteStation";
+
+interface StationCardProps {
+  station: Station;
+}
+
+export function StationCard({ station }: StationCardProps) {
+  const [eyeInput, setEyeInput] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const assignEye = useAssignEye();
+  const unassignEye = useUnassignEye();
+  const deleteStation = useDeleteStation();
+
+  function handleAssign(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = eyeInput.trim();
+    if (trimmed.length === 0) return;
+    assignEye.mutate(
+      { stationId: station.id, eyeId: trimmed },
+      { onSuccess: () => setEyeInput("") },
+    );
+  }
+
+  function handleUnassign() {
+    unassignEye.mutate(station.id);
+  }
+
+  function handleDelete() {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    deleteStation.mutate(station.id, {
+      onError: () => setConfirmDelete(false),
+    });
+  }
+
+  const mutationError =
+    assignEye.error ?? unassignEye.error ?? deleteStation.error;
+
+  return (
+    <div className="rounded-lg border bg-white p-5 shadow-sm">
+      <div className="mb-3 flex items-start justify-between">
+        <div>
+          <h3 className="font-semibold text-gray-900">{station.name}</h3>
+          {station.location && (
+            <p className="text-sm text-gray-500">{station.location}</p>
+          )}
+        </div>
+
+        <div className="flex gap-1">
+          {confirmDelete ? (
+            <>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleteStation.isPending}
+                className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteStation.isPending ? "Deleting..." : "Confirm"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(false)}
+                className="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 hover:bg-gray-200"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={handleDelete}
+              className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600"
+              aria-label={`Delete station ${station.name}`}
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="border-t pt-3">
+        {station.eyeId !== null ? (
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-3 py-1 text-sm font-medium text-green-700">
+              {station.eyeId}
+              <button
+                type="button"
+                onClick={handleUnassign}
+                disabled={unassignEye.isPending}
+                className="ml-1 rounded-full p-0.5 hover:bg-green-200 disabled:opacity-50"
+                aria-label={`Unassign eye ${station.eyeId}`}
+              >
+                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </span>
+          </div>
+        ) : (
+          <form onSubmit={handleAssign} className="flex items-center gap-2">
+            <input
+              type="text"
+              value={eyeInput}
+              onChange={(e) => setEyeInput(e.target.value)}
+              placeholder="Enter eye ID (e.g. eye-1)"
+              className="flex-1 rounded border px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              type="submit"
+              disabled={assignEye.isPending || eyeInput.trim().length === 0}
+              className="rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {assignEye.isPending ? "Assigning..." : "Assign"}
+            </button>
+          </form>
+        )}
+      </div>
+
+      {mutationError && (
+        <p className="mt-2 text-sm text-red-600">{mutationError.message}</p>
+      )}
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/features/stations/components/StationList.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationList.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { createWrapper } from "../../../test-utils";
+import { StationList } from "./StationList";
+import type { Station } from "../stations.types";
+
+vi.mock("../hooks/useStations", () => ({ useStations: vi.fn() }));
+
+import { useStations } from "../hooks/useStations";
+
+const sampleStations: Station[] = [
+  { id: "station-aaa", name: "Polishing", location: "Floor 2", eyeId: "eye-1" },
+  { id: "station-bbb", name: "Casting", location: "", eyeId: null },
+];
+
+describe("StationList", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should show loading state", () => {
+    vi.mocked(useStations).mockReturnValue({
+      isLoading: true,
+      error: null,
+      data: undefined,
+    } as unknown as ReturnType<typeof useStations>);
+
+    render(<StationList />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("Loading stations...")).toBeInTheDocument();
+  });
+
+  it("should show error message when fetch fails", () => {
+    vi.mocked(useStations).mockReturnValue({
+      isLoading: false,
+      error: new Error("Network error"),
+      data: undefined,
+    } as unknown as ReturnType<typeof useStations>);
+
+    render(<StationList />, { wrapper: createWrapper() });
+
+    expect(screen.getByText(/Network error/)).toBeInTheDocument();
+  });
+
+  it("should show empty state when there are no stations", () => {
+    vi.mocked(useStations).mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: [],
+    } as unknown as ReturnType<typeof useStations>);
+
+    render(<StationList />, { wrapper: createWrapper() });
+
+    expect(
+      screen.getByText("No stations yet. Create one above."),
+    ).toBeInTheDocument();
+  });
+
+  it("should render station cards", () => {
+    vi.mocked(useStations).mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: sampleStations,
+    } as unknown as ReturnType<typeof useStations>);
+
+    render(<StationList />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("Polishing")).toBeInTheDocument();
+    expect(screen.getByText("Floor 2")).toBeInTheDocument();
+    expect(screen.getByText("Casting")).toBeInTheDocument();
+  });
+});

--- a/manu-gen/frontend/src/features/stations/components/StationList.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationList.tsx
@@ -1,0 +1,36 @@
+import { useStations } from "../hooks/useStations";
+import { StationCard } from "./StationCard";
+
+export function StationList() {
+  const { data, isLoading, error } = useStations();
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading stations...</p>;
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-600">
+        Failed to load stations: {error.message}
+      </p>
+    );
+  }
+
+  const stations = data ?? [];
+
+  if (stations.length === 0) {
+    return (
+      <p className="text-sm text-gray-500">
+        No stations yet. Create one above.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {stations.map((station) => (
+        <StationCard key={station.id} station={station} />
+      ))}
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/features/stations/components/StationsPage.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationsPage.tsx
@@ -1,0 +1,17 @@
+import { CreateStationForm } from "./CreateStationForm";
+import { StationList } from "./StationList";
+
+export function StationsPage() {
+  return (
+    <div className="mx-auto max-w-6xl">
+      <h2 className="mb-6 text-xl font-semibold text-gray-900">Stations</h2>
+
+      <div className="mb-8 rounded-lg border bg-white p-6 shadow-sm">
+        <h3 className="mb-4 text-lg font-semibold">New Station</h3>
+        <CreateStationForm />
+      </div>
+
+      <StationList />
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/features/stations/hooks/useAssignEye.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useAssignEye.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+import type { Station } from "../stations.types";
+
+export function useAssignEye() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ stationId, eyeId }: { stationId: string; eyeId: string }) =>
+      apiClient.put<Station>(`/stations/${stationId}/eye`, { eyeId }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["stations"] });
+    },
+  });
+}

--- a/manu-gen/frontend/src/features/stations/hooks/useCreateStation.test.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useCreateStation.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient } from "@tanstack/react-query";
+import { vi } from "vitest";
+import { createWrapper } from "../../../test-utils";
+import { useCreateStation } from "./useCreateStation";
+import type { Station } from "../stations.types";
+
+vi.mock("../../../shared/api/client", () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+}));
+
+import { apiClient } from "../../../shared/api/client";
+
+const sampleStation: Station = {
+  id: "station-abc12345",
+  name: "Polishing",
+  location: "Floor 2",
+  eyeId: null,
+};
+
+describe("useCreateStation", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should call POST /stations with the provided data", async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(sampleStation);
+
+    const { result } = renderHook(() => useCreateStation(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Polishing", location: "Floor 2" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(apiClient.post).toHaveBeenCalledWith("/stations", {
+      name: "Polishing",
+      location: "Floor 2",
+    });
+  });
+
+  it("should invalidate the stations query on success", async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(sampleStation);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    queryClient.setQueryData(["stations"], []);
+
+    const { result } = renderHook(() => useCreateStation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate({ name: "Polishing" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const queryState = queryClient.getQueryState(["stations"]);
+    expect(queryState?.isInvalidated).toBe(true);
+  });
+
+  it("should expose the error on failure", async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(new Error("Server error"));
+
+    const { result } = renderHook(() => useCreateStation(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Polishing" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe("Server error");
+  });
+});

--- a/manu-gen/frontend/src/features/stations/hooks/useCreateStation.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useCreateStation.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+import type { Station } from "../stations.types";
+import type { CreateStationFormValues } from "../stations.schema";
+
+export function useCreateStation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateStationFormValues) =>
+      apiClient.post<Station>("/stations", data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["stations"] });
+    },
+  });
+}

--- a/manu-gen/frontend/src/features/stations/hooks/useDeleteStation.test.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useDeleteStation.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient } from "@tanstack/react-query";
+import { vi } from "vitest";
+import { createWrapper } from "../../../test-utils";
+import { useDeleteStation } from "./useDeleteStation";
+
+vi.mock("../../../shared/api/client", () => ({
+  apiClient: {
+    deleteNoContent: vi.fn(),
+  },
+}));
+
+import { apiClient } from "../../../shared/api/client";
+
+describe("useDeleteStation", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should call DELETE /stations/:id", async () => {
+    vi.mocked(apiClient.deleteNoContent).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteStation(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("station-abc12345");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(apiClient.deleteNoContent).toHaveBeenCalledWith(
+      "/stations/station-abc12345",
+    );
+  });
+
+  it("should invalidate the stations query on success", async () => {
+    vi.mocked(apiClient.deleteNoContent).mockResolvedValue(undefined);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    queryClient.setQueryData(["stations"], []);
+
+    const { result } = renderHook(() => useDeleteStation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate("station-abc12345");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const queryState = queryClient.getQueryState(["stations"]);
+    expect(queryState?.isInvalidated).toBe(true);
+  });
+
+  it("should expose the error on failure", async () => {
+    vi.mocked(apiClient.deleteNoContent).mockRejectedValue(
+      new Error("Cannot delete"),
+    );
+
+    const { result } = renderHook(() => useDeleteStation(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("station-abc12345");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe("Cannot delete");
+  });
+});

--- a/manu-gen/frontend/src/features/stations/hooks/useDeleteStation.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useDeleteStation.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+
+export function useDeleteStation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (stationId: string) =>
+      apiClient.deleteNoContent(`/stations/${stationId}`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["stations"] });
+    },
+  });
+}

--- a/manu-gen/frontend/src/features/stations/hooks/useStations.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useStations.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+import type { Station } from "../stations.types";
+
+export function useStations() {
+  return useQuery({
+    queryKey: ["stations"],
+    queryFn: () => apiClient.get<Station[]>("/stations?limit=100"),
+  });
+}

--- a/manu-gen/frontend/src/features/stations/hooks/useUnassignEye.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useUnassignEye.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+import type { Station } from "../stations.types";
+
+export function useUnassignEye() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (stationId: string) =>
+      apiClient.delete<Station>(`/stations/${stationId}/eye`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["stations"] });
+    },
+  });
+}

--- a/manu-gen/frontend/src/features/stations/stations.schema.ts
+++ b/manu-gen/frontend/src/features/stations/stations.schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createStationSchema = z.object({
+  name: z.string().min(1, "Station name is required"),
+  location: z.string().optional(),
+});
+
+export type CreateStationFormValues = z.infer<typeof createStationSchema>;

--- a/manu-gen/frontend/src/features/stations/stations.types.ts
+++ b/manu-gen/frontend/src/features/stations/stations.types.ts
@@ -1,0 +1,6 @@
+export interface Station {
+  id: string;
+  name: string;
+  location: string;
+  eyeId: string | null;
+}

--- a/manu-gen/frontend/src/shared/api/client.ts
+++ b/manu-gen/frontend/src/shared/api/client.ts
@@ -18,8 +18,26 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     throw new Error(body.message ?? response.statusText);
   }
 
-  // Unvalidated cast — production code should run a Zod safeParse here.
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
   return response.json() as Promise<T>;
+}
+
+async function requestNoContent(path: string, init?: RequestInit): Promise<void> {
+  const { headers: initHeaders, ...restInit } = init ?? {};
+  const response = await fetch(`${BASE_URL}${path}`, {
+    headers: { ...initHeaders },
+    ...restInit,
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({
+      message: response.statusText,
+    }))) as ApiError;
+    throw new Error(body.message ?? response.statusText);
+  }
 }
 
 export const apiClient = {
@@ -29,4 +47,13 @@ export const apiClient = {
       method: "POST",
       body: JSON.stringify(body),
     }),
+  put: <T>(path: string, body: unknown) =>
+    request<T>(path, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+  delete: <T>(path: string) =>
+    request<T>(path, { method: "DELETE" }),
+  deleteNoContent: (path: string) =>
+    requestNoContent(path, { method: "DELETE" }),
 };

--- a/manu-gen/frontend/src/shared/components/Layout.tsx
+++ b/manu-gen/frontend/src/shared/components/Layout.tsx
@@ -1,0 +1,16 @@
+import { Sidebar, type PageId } from "./Sidebar";
+
+interface LayoutProps {
+  currentPage: PageId;
+  onNavigate: (page: PageId) => void;
+  children: React.ReactNode;
+}
+
+export function Layout({ currentPage, onNavigate, children }: LayoutProps) {
+  return (
+    <div className="flex min-h-screen bg-gray-50">
+      <Sidebar currentPage={currentPage} onNavigate={onNavigate} />
+      <main className="flex-1 p-6 md:p-8">{children}</main>
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/shared/components/Sidebar.tsx
+++ b/manu-gen/frontend/src/shared/components/Sidebar.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+
+export type PageId = "orders" | "stations";
+
+interface SidebarProps {
+  currentPage: PageId;
+  onNavigate: (page: PageId) => void;
+}
+
+const NAV_ITEMS: { id: PageId; label: string }[] = [
+  { id: "orders", label: "Orders" },
+  { id: "stations", label: "Stations" },
+];
+
+export function Sidebar({ currentPage, onNavigate }: SidebarProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setMobileOpen(!mobileOpen)}
+        className="fixed top-4 left-4 z-50 rounded-md bg-white p-2 shadow-md md:hidden"
+        aria-label="Toggle navigation"
+      >
+        <svg
+          className="h-5 w-5 text-gray-700"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          {mobileOpen ? (
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          ) : (
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          )}
+        </svg>
+      </button>
+
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/20 md:hidden"
+          onClick={() => setMobileOpen(false)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") setMobileOpen(false);
+          }}
+          role="presentation"
+        />
+      )}
+
+      <aside
+        className={`fixed inset-y-0 left-0 z-40 flex w-56 flex-col border-r bg-white transition-transform md:static md:translate-x-0 ${
+          mobileOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        <div className="border-b px-5 py-4">
+          <h1 className="text-lg font-bold text-gray-900">Manu Tracker</h1>
+        </div>
+
+        <nav className="flex-1 px-3 py-4">
+          {NAV_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => {
+                onNavigate(item.id);
+                setMobileOpen(false);
+              }}
+              className={`mb-1 w-full rounded-md px-3 py-2 text-left text-sm font-medium transition-colors ${
+                currentPage === item.id
+                  ? "bg-blue-50 text-blue-700"
+                  : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/manu-gen/frontend/vite.config.ts
+++ b/manu-gen/frontend/vite.config.ts
@@ -21,6 +21,17 @@ export default defineConfig({
           });
         },
       },
+      "/stations": {
+        target: API_TARGET,
+        configure: (proxy) => {
+          proxy.on("proxyReq", (_, req) => {
+            console.log(`[proxy] → ${req.method} ${req.url}`);
+          });
+          proxy.on("proxyRes", (res, req) => {
+            console.log(`[proxy] ← ${res.statusCode} ${req.method} ${req.url}`);
+          });
+        },
+      },
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Adds a full station management UI so operators can create stations, assign/unassign eye devices, and delete stations — all from the browser instead of raw API calls.

## Changes

### Backend
- `DELETE /stations/:id` — cascade-deletes tracking events, unassigns eye, removes station (all in a single transaction)
- `DELETE /stations/:id/eye` — unassigns the eye from a station
- 37 backend tests covering all station endpoints

### Frontend
- Sidebar navigation with Orders and Stations pages (mobile-responsive with hamburger toggle)
- `Layout` + `Sidebar` shared components, `OrdersPage` extracted from `App.tsx`
- Station cards with inline eye assignment (text input + assign button) and eye badge with unassign
- Create station form with Zod validation (name required, location optional)
- Delete station with confirmation step, resets on error
- `apiClient.put`, `apiClient.delete`, `apiClient.deleteNoContent` methods
- Vite proxy for `/stations` routes
- 45 frontend tests (components + hooks)

## Test plan
- [ ] `npm test` in `manu-gen/backend` — 37 station tests pass
- [ ] `npm test` in `manu-gen/frontend` — 45 tests pass
- [ ] `npm run typecheck` + `npm run lint` + `npm run build` in frontend — all clean
- [ ] `docker-compose up --build` → create station → assign eye → start manu-eye → verify registration → delete station

## Notes
- Eye assignment is a manual text input for POC; future improvement: dropdown of known eyes
- Station delete is a full cascade (events + eye) — no 409 blocking

Made with [Cursor](https://cursor.com)