### PR TITLE
feat(dashboard): add reporting dashboard with live order board and stage analytics

### DIFF
--- a/manu-gen/backend/src/app.ts
+++ b/manu-gen/backend/src/app.ts
@@ -4,6 +4,7 @@ import { ordersRouter } from "./features/orders/orders.controller.js";
 import { stationsRouter } from "./features/stations/stations.controller.js";
 import { eyesRouter } from "./features/eyes/eyes.controller.js";
 import { eventsRouter } from "./features/events/events.controller.js";
+import { analyticsRouter } from "./features/analytics/analytics.controller.js";
 import { errorHandler } from "./shared/middleware/error-handler.js";
 import { logger } from "./shared/logger.js";
 
@@ -35,4 +36,5 @@ app.use("/orders", ordersRouter);
 app.use("/stations", stationsRouter);
 app.use("/eyes", eyesRouter);
 app.use("/events", eventsRouter);
+app.use("/analytics", analyticsRouter);
 app.use(errorHandler);

--- a/manu-gen/backend/src/features/analytics/analytics.controller.ts
+++ b/manu-gen/backend/src/features/analytics/analytics.controller.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import * as analyticsService from "./analytics.service.js";
+
+export const analyticsRouter = Router();
+
+analyticsRouter.get("/durations", (req, res, next) => {
+  try {
+    const durations = analyticsService.getStationDurations();
+    res.json(durations);
+  } catch (err) {
+    next(err);
+  }
+});

--- a/manu-gen/backend/src/features/analytics/analytics.schema.ts
+++ b/manu-gen/backend/src/features/analytics/analytics.schema.ts
@@ -1,0 +1,25 @@
+export interface StationDurationRow {
+  station_id: string;
+  station_name: string;
+  avg_seconds: number;
+  max_seconds: number;
+  order_count: number;
+}
+
+export interface StationDuration {
+  stationId: string;
+  stationName: string;
+  avgSeconds: number;
+  maxSeconds: number;
+  orderCount: number;
+}
+
+export function toStationDuration(row: StationDurationRow): StationDuration {
+  return {
+    stationId: row.station_id,
+    stationName: row.station_name,
+    avgSeconds: Math.round(row.avg_seconds),
+    maxSeconds: Math.round(row.max_seconds),
+    orderCount: row.order_count,
+  };
+}

--- a/manu-gen/backend/src/features/analytics/analytics.service.test.ts
+++ b/manu-gen/backend/src/features/analytics/analytics.service.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import db from "../../db.js";
+import * as analyticsService from "./analytics.service.js";
+import * as ordersService from "../orders/orders.service.js";
+import * as stationsService from "../stations/stations.service.js";
+import * as eventsService from "../events/events.service.js";
+
+beforeEach(() => {
+  db.exec("DELETE FROM tracking_events");
+  db.exec("DELETE FROM orders");
+  db.exec("DELETE FROM stations");
+  db.exec("DELETE FROM sqlite_sequence WHERE name = 'orders'");
+  db.exec("DELETE FROM sqlite_sequence WHERE name = 'tracking_events'");
+});
+
+describe("getStationDurations", () => {
+  it("should return empty array when no events exist", () => {
+    expect(analyticsService.getStationDurations()).toEqual([]);
+  });
+
+  it("should exclude stations where the order is still present (no next event)", () => {
+    const order = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    const station = stationsService.createStation({ name: "Moulding" });
+
+    eventsService.createEvent({
+      trayCode: order.trayCode,
+      stationId: station.id,
+      eyeId: "eye-1",
+      capturedAt: "2026-03-18T10:00:00",
+    });
+
+    expect(analyticsService.getStationDurations()).toEqual([]);
+  });
+
+  it("should compute avg and max durations across orders", () => {
+    const order1 = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    const order2 = ordersService.createOrder({ customerName: "B", productType: "Y", quantity: 1 });
+    const station1 = stationsService.createStation({ name: "Moulding" });
+    const station2 = stationsService.createStation({ name: "Drying Room" });
+
+    eventsService.createEvent({
+      trayCode: order1.trayCode,
+      stationId: station1.id,
+      eyeId: "eye-1",
+      capturedAt: "2026-03-18T10:00:00",
+    });
+    eventsService.createEvent({
+      trayCode: order1.trayCode,
+      stationId: station2.id,
+      eyeId: "eye-2",
+      capturedAt: "2026-03-18T11:00:00",
+    });
+
+    eventsService.createEvent({
+      trayCode: order2.trayCode,
+      stationId: station1.id,
+      eyeId: "eye-1",
+      capturedAt: "2026-03-18T12:00:00",
+    });
+    eventsService.createEvent({
+      trayCode: order2.trayCode,
+      stationId: station2.id,
+      eyeId: "eye-2",
+      capturedAt: "2026-03-18T14:00:00",
+    });
+
+    const durations = analyticsService.getStationDurations();
+    const moulding = durations.find((d) => d.stationName === "Moulding");
+    expect(moulding).toBeDefined();
+    expect(moulding!.orderCount).toBe(2);
+    expect(moulding!.avgSeconds).toBe(5400);
+    expect(moulding!.maxSeconds).toBe(7200);
+  });
+
+  it("should compute correct durations with Z-suffixed timestamps", () => {
+    const order = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    const station1 = stationsService.createStation({ name: "Moulding" });
+    const station2 = stationsService.createStation({ name: "Drying Room" });
+
+    eventsService.createEvent({
+      trayCode: order.trayCode,
+      stationId: station1.id,
+      eyeId: "eye-1",
+      capturedAt: "2026-03-18T10:00:00Z",
+    });
+    eventsService.createEvent({
+      trayCode: order.trayCode,
+      stationId: station2.id,
+      eyeId: "eye-2",
+      capturedAt: "2026-03-18T12:00:00Z",
+    });
+
+    const durations = analyticsService.getStationDurations();
+    const moulding = durations.find((d) => d.stationName === "Moulding");
+    expect(moulding).toBeDefined();
+    expect(moulding!.avgSeconds).toBe(7200);
+    expect(moulding!.maxSeconds).toBe(7200);
+  });
+});

--- a/manu-gen/backend/src/features/analytics/analytics.service.ts
+++ b/manu-gen/backend/src/features/analytics/analytics.service.ts
@@ -1,0 +1,30 @@
+import db from "../../db.js";
+import type { StationDurationRow, StationDuration } from "./analytics.schema.js";
+import { toStationDuration } from "./analytics.schema.js";
+
+const stmtDurations = db.prepare(`
+  SELECT
+    s.id   AS station_id,
+    s.name AS station_name,
+    AVG(duration_seconds) AS avg_seconds,
+    MAX(duration_seconds) AS max_seconds,
+    COUNT(DISTINCT te.tray_code) AS order_count
+  FROM (
+    SELECT
+      te.tray_code,
+      te.station_id,
+      (julianday(LEAD(te.captured_at) OVER (
+        PARTITION BY te.tray_code ORDER BY te.captured_at
+      )) - julianday(te.captured_at)) * 86400 AS duration_seconds
+    FROM tracking_events te
+  ) te
+  JOIN stations s ON s.id = te.station_id
+  WHERE te.duration_seconds IS NOT NULL
+  GROUP BY s.id, s.name
+  ORDER BY s.name
+`);
+
+export function getStationDurations(): StationDuration[] {
+  const rows = stmtDurations.all() as StationDurationRow[];
+  return rows.map(toStationDuration);
+}

--- a/manu-gen/backend/src/features/events/events.controller.test.ts
+++ b/manu-gen/backend/src/features/events/events.controller.test.ts
@@ -8,6 +8,7 @@ let testStationId: string;
 beforeEach(async () => {
   db.exec("DELETE FROM tracking_events");
   db.exec("DELETE FROM stations");
+  db.exec("DELETE FROM sqlite_sequence WHERE name = 'tracking_events'");
 
   const stationRes = await request(app).post("/stations").send({ name: "Test Station" });
   testStationId = stationRes.body.id;

--- a/manu-gen/backend/src/features/events/events.service.test.ts
+++ b/manu-gen/backend/src/features/events/events.service.test.ts
@@ -6,6 +6,7 @@ import * as eventsService from "./events.service.js";
 beforeEach(() => {
   db.exec("DELETE FROM tracking_events");
   db.exec("DELETE FROM stations");
+  db.exec("DELETE FROM sqlite_sequence WHERE name = 'tracking_events'");
 });
 
 function createTestStation(): string {

--- a/manu-gen/backend/src/features/orders/orders.controller.ts
+++ b/manu-gen/backend/src/features/orders/orders.controller.ts
@@ -59,11 +59,30 @@ ordersRouter.get("/", (req, res, next) => {
   }
 });
 
+ordersRouter.get("/board", (req, res, next) => {
+  try {
+    const board = ordersService.getOrderBoard();
+    res.json(board);
+  } catch (err) {
+    next(err);
+  }
+});
+
 ordersRouter.get("/:id", (req, res, next) => {
   try {
     const id = parseOrderId(req.params.id);
     const order = ordersService.getOrderById(id);
     res.json(order);
+  } catch (err) {
+    next(err);
+  }
+});
+
+ordersRouter.get("/:id/history", (req, res, next) => {
+  try {
+    const id = parseOrderId(req.params.id);
+    const history = ordersService.getOrderHistory(id);
+    res.json(history);
   } catch (err) {
     next(err);
   }

--- a/manu-gen/backend/src/features/orders/orders.dashboard.test.ts
+++ b/manu-gen/backend/src/features/orders/orders.dashboard.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import db from "../../db.js";
+import * as ordersService from "./orders.service.js";
+import * as stationsService from "../stations/stations.service.js";
+import * as eventsService from "../events/events.service.js";
+
+beforeEach(() => {
+  db.exec("DELETE FROM tracking_events");
+  db.exec("DELETE FROM orders");
+  db.exec("DELETE FROM stations");
+  db.exec("DELETE FROM sqlite_sequence WHERE name = 'orders'");
+  db.exec("DELETE FROM sqlite_sequence WHERE name = 'tracking_events'");
+});
+
+describe("getOrderBoard", () => {
+  it("should return empty array when no orders exist", () => {
+    expect(ordersService.getOrderBoard()).toEqual([]);
+  });
+
+  it("should return orders with null station when no events exist", () => {
+    ordersService.createOrder({ customerName: "AlphaTech", productType: "Crown", quantity: 1 });
+
+    const board = ordersService.getOrderBoard();
+    expect(board).toHaveLength(1);
+    expect(board[0].orderNumber).toBe("ORD-0001");
+    expect(board[0].currentStation).toBeNull();
+    expect(board[0].lastSeenAt).toBeNull();
+  });
+
+  it("should return the latest station for an order with events", () => {
+    const order = ordersService.createOrder({ customerName: "AlphaTech", productType: "Crown", quantity: 1 });
+    const station1 = stationsService.createStation({ name: "Moulding" });
+    const station2 = stationsService.createStation({ name: "Drying Room" });
+
+    eventsService.createEvent({
+      trayCode: order.trayCode,
+      stationId: station1.id,
+      eyeId: "eye-1",
+      capturedAt: "2026-03-18T10:00:00",
+    });
+    eventsService.createEvent({
+      trayCode: order.trayCode,
+      stationId: station2.id,
+      eyeId: "eye-2",
+      capturedAt: "2026-03-18T12:00:00",
+    });
+
+    const board = ordersService.getOrderBoard();
+    expect(board).toHaveLength(1);
+    expect(board[0].currentStation).toEqual({ id: station2.id, name: "Drying Room" });
+    expect(board[0].lastSeenAt).toBe("2026-03-18T12:00:00");
+  });
+
+  it("should sort orders with longest wait first, unseen last", () => {
+    const order1 = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    ordersService.createOrder({ customerName: "B", productType: "Y", quantity: 1 });
+    const order3 = ordersService.createOrder({ customerName: "C", productType: "Z", quantity: 1 });
+
+    const station = stationsService.createStation({ name: "Moulding" });
+
+    eventsService.createEvent({
+      trayCode: order1.trayCode,
+      stationId: station.id,
+      eyeId: "eye-1",
+      capturedAt: "2026-03-18T14:00:00",
+    });
+    eventsService.createEvent({
+      trayCode: order3.trayCode,
+      stationId: station.id,
+      eyeId: "eye-1",
+      capturedAt: "2026-03-18T10:00:00",
+    });
+
+    const board = ordersService.getOrderBoard();
+    expect(board).toHaveLength(3);
+    expect(board[0].customerName).toBe("C");
+    expect(board[1].customerName).toBe("A");
+    expect(board[2].customerName).toBe("B");
+  });
+
+  it("should normalize space-separated SQLite datetimes to ISO format", () => {
+    const order = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    const station = stationsService.createStation({ name: "Moulding" });
+
+    db.prepare(
+      "INSERT INTO tracking_events (tray_code, station_id, eye_id, captured_at) VALUES (?, ?, ?, ?)",
+    ).run(order.trayCode, station.id, "eye-1", "2026-03-18 14:30:00");
+
+    const board = ordersService.getOrderBoard();
+    expect(board).toHaveLength(1);
+    expect(board[0].lastSeenAt).toBe("2026-03-18T14:30:00");
+    expect(board[0].createdAt).not.toContain(" ");
+  });
+
+  it("should handle Z-suffixed timestamps from eye scanners without double-Z", () => {
+    const order = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    const station = stationsService.createStation({ name: "Moulding" });
+
+    db.prepare(
+      "INSERT INTO tracking_events (tray_code, station_id, eye_id, captured_at) VALUES (?, ?, ?, ?)",
+    ).run(order.trayCode, station.id, "eye-1", "2026-03-18T14:30:00Z");
+
+    const board = ordersService.getOrderBoard();
+    expect(board).toHaveLength(1);
+    expect(board[0].lastSeenAt).toBe("2026-03-18T14:30:00");
+    expect(board[0].lastSeenAt).not.toContain("Z");
+  });
+});
+
+describe("getOrderHistory", () => {
+  it("should return empty array when order has no events", () => {
+    const order = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    expect(ordersService.getOrderHistory(order.id)).toEqual([]);
+  });
+
+  it("should throw 404 for non-existent order", () => {
+    expect(() => ordersService.getOrderHistory(999)).toThrow(
+      expect.objectContaining({ statusCode: 404 }),
+    );
+  });
+
+  it("should return timeline with computed durations", () => {
+    const order = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    const station1 = stationsService.createStation({ name: "Moulding" });
+    const station2 = stationsService.createStation({ name: "Drying Room" });
+    const station3 = stationsService.createStation({ name: "Kiln" });
+
+    eventsService.createEvent({
+      trayCode: order.trayCode,
+      stationId: station1.id,
+      eyeId: "eye-1",
+      capturedAt: "2026-03-18T10:00:00",
+    });
+    eventsService.createEvent({
+      trayCode: order.trayCode,
+      stationId: station2.id,
+      eyeId: "eye-2",
+      capturedAt: "2026-03-18T11:00:00",
+    });
+    eventsService.createEvent({
+      trayCode: order.trayCode,
+      stationId: station3.id,
+      eyeId: "eye-3",
+      capturedAt: "2026-03-18T13:30:00",
+    });
+
+    const history = ordersService.getOrderHistory(order.id);
+    expect(history).toHaveLength(3);
+
+    expect(history[0].station).toBe("Moulding");
+    expect(history[0].durationSeconds).toBe(3600);
+
+    expect(history[1].station).toBe("Drying Room");
+    expect(history[1].durationSeconds).toBe(9000);
+
+    expect(history[2].station).toBe("Kiln");
+    expect(history[2].durationSeconds).toBeNull();
+  });
+
+  it("should normalize space-separated datetimes and compute correct durations", () => {
+    const order = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    const station1 = stationsService.createStation({ name: "Moulding" });
+    const station2 = stationsService.createStation({ name: "Drying" });
+
+    const insertEvent = db.prepare(
+      "INSERT INTO tracking_events (tray_code, station_id, eye_id, captured_at) VALUES (?, ?, ?, ?)",
+    );
+    insertEvent.run(order.trayCode, station1.id, "eye-1", "2026-03-18 10:00:00");
+    insertEvent.run(order.trayCode, station2.id, "eye-2", "2026-03-18 11:30:00");
+
+    const history = ordersService.getOrderHistory(order.id);
+    expect(history).toHaveLength(2);
+    expect(history[0].arrivedAt).toBe("2026-03-18T10:00:00");
+    expect(history[0].durationSeconds).toBe(5400);
+    expect(history[1].arrivedAt).toBe("2026-03-18T11:30:00");
+  });
+
+  it("should handle Z-suffixed timestamps without double-Z in arrivedAt", () => {
+    const order = ordersService.createOrder({ customerName: "A", productType: "X", quantity: 1 });
+    const station1 = stationsService.createStation({ name: "Moulding" });
+    const station2 = stationsService.createStation({ name: "Drying" });
+
+    const insertEvent = db.prepare(
+      "INSERT INTO tracking_events (tray_code, station_id, eye_id, captured_at) VALUES (?, ?, ?, ?)",
+    );
+    insertEvent.run(order.trayCode, station1.id, "eye-1", "2026-03-18T10:00:00Z");
+    insertEvent.run(order.trayCode, station2.id, "eye-2", "2026-03-18T11:30:00Z");
+
+    const history = ordersService.getOrderHistory(order.id);
+    expect(history).toHaveLength(2);
+    expect(history[0].arrivedAt).toBe("2026-03-18T10:00:00");
+    expect(history[0].arrivedAt).not.toContain("Z");
+    expect(history[0].durationSeconds).toBe(5400);
+  });
+});

--- a/manu-gen/backend/src/features/orders/orders.schema.ts
+++ b/manu-gen/backend/src/features/orders/orders.schema.ts
@@ -43,3 +43,76 @@ export function toOrder(row: OrderRow): Order {
     createdAt: row.created_at,
   };
 }
+
+export interface BoardOrderRow {
+  id: number;
+  order_number: string;
+  customer_name: string;
+  product_type: string;
+  tray_code: string;
+  created_at: string;
+  station_id: string | null;
+  station_name: string | null;
+  last_seen_at: string | null;
+}
+
+export interface BoardOrder {
+  id: number;
+  orderNumber: string;
+  customerName: string;
+  productType: string;
+  trayCode: string;
+  createdAt: string;
+  currentStation: { id: string; name: string } | null;
+  lastSeenAt: string | null;
+}
+
+function toIso(raw: string): string {
+  return raw.replace(" ", "T").replace(/Z$/, "");
+}
+
+function parseUtcMs(raw: string): number {
+  return new Date(toIso(raw) + "Z").getTime();
+}
+
+export function toBoardOrder(row: BoardOrderRow): BoardOrder {
+  return {
+    id: row.id,
+    orderNumber: row.order_number,
+    customerName: row.customer_name,
+    productType: row.product_type,
+    trayCode: row.tray_code,
+    createdAt: toIso(row.created_at),
+    currentStation:
+      row.station_id && row.station_name
+        ? { id: row.station_id, name: row.station_name }
+        : null,
+    lastSeenAt: row.last_seen_at ? toIso(row.last_seen_at) : null,
+  };
+}
+
+export interface OrderHistoryRow {
+  station_name: string;
+  arrived_at: string;
+  next_arrived_at: string | null;
+}
+
+export interface OrderHistoryEntry {
+  station: string;
+  arrivedAt: string;
+  durationSeconds: number | null;
+}
+
+export function toOrderHistoryEntry(row: OrderHistoryRow): OrderHistoryEntry {
+  let durationSeconds: number | null = null;
+  if (row.next_arrived_at) {
+    const arrived = parseUtcMs(row.arrived_at);
+    const next = parseUtcMs(row.next_arrived_at);
+    durationSeconds = Math.floor((next - arrived) / 1000);
+  }
+  return {
+    station: row.station_name,
+    arrivedAt: toIso(row.arrived_at),
+    durationSeconds,
+  };
+}

--- a/manu-gen/backend/src/features/orders/orders.service.ts
+++ b/manu-gen/backend/src/features/orders/orders.service.ts
@@ -1,8 +1,16 @@
 import QRCode from "qrcode";
 import db from "../../db.js";
 import { AppError } from "../../shared/errors/app-error.js";
-import type { CreateOrderInput, Order, OrderRow } from "./orders.schema.js";
-import { toOrder } from "./orders.schema.js";
+import type {
+  CreateOrderInput,
+  Order,
+  OrderRow,
+  BoardOrderRow,
+  BoardOrder,
+  OrderHistoryRow,
+  OrderHistoryEntry,
+} from "./orders.schema.js";
+import { toOrder, toBoardOrder, toOrderHistoryEntry } from "./orders.schema.js";
 
 const QR_OPTIONS = {
   width: 300,
@@ -75,6 +83,57 @@ export function getOrderByTrayCode(trayCode: string): Order {
 export function listOrders({ limit = 50, offset = 0 }: { limit?: number; offset?: number } = {}): Order[] {
   const rows = stmtListOrders.all(limit, offset) as OrderRow[];
   return rows.map(toOrder);
+}
+
+const stmtOrderBoard = db.prepare(`
+  SELECT
+    o.id,
+    o.order_number,
+    o.customer_name,
+    o.product_type,
+    o.tray_code,
+    o.created_at,
+    s.id   AS station_id,
+    s.name AS station_name,
+    ranked.captured_at AS last_seen_at
+  FROM orders o
+  LEFT JOIN (
+    SELECT
+      tray_code,
+      station_id,
+      captured_at,
+      ROW_NUMBER() OVER (PARTITION BY tray_code ORDER BY captured_at DESC) AS rn
+    FROM tracking_events
+  ) ranked ON ranked.tray_code = o.tray_code AND ranked.rn = 1
+  LEFT JOIN stations s ON s.id = ranked.station_id
+  ORDER BY
+    CASE WHEN ranked.captured_at IS NULL THEN 1 ELSE 0 END,
+    ranked.captured_at ASC
+`);
+
+export function getOrderBoard(): BoardOrder[] {
+  const rows = stmtOrderBoard.all() as BoardOrderRow[];
+  return rows.map(toBoardOrder);
+}
+
+const stmtOrderHistory = db.prepare(`
+  SELECT
+    s.name AS station_name,
+    te.captured_at AS arrived_at,
+    LEAD(te.captured_at) OVER (ORDER BY te.captured_at) AS next_arrived_at
+  FROM tracking_events te
+  JOIN stations s ON s.id = te.station_id
+  WHERE te.tray_code = (SELECT tray_code FROM orders WHERE id = ?)
+  ORDER BY te.captured_at
+`);
+
+export function getOrderHistory(orderId: number): OrderHistoryEntry[] {
+  const exists = stmtGetById.get(orderId) as OrderRow | undefined;
+  if (!exists) {
+    throw new AppError(404, `Order with id ${orderId} not found`);
+  }
+  const rows = stmtOrderHistory.all(orderId) as OrderHistoryRow[];
+  return rows.map(toOrderHistoryEntry);
 }
 
 export async function generateQrCode(id: number): Promise<Buffer> {

--- a/manu-gen/backend/vitest.config.ts
+++ b/manu-gen/backend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+  },
+});

--- a/manu-gen/frontend/src/App.tsx
+++ b/manu-gen/frontend/src/App.tsx
@@ -1,14 +1,16 @@
 import { useState } from "react";
 import { Layout } from "./shared/components/Layout";
 import type { PageId } from "./shared/components/Sidebar";
+import { DashboardPage } from "./features/dashboard/components/DashboardPage";
 import { OrdersPage } from "./features/orders/components/OrdersPage";
 import { StationsPage } from "./features/stations/components/StationsPage";
 
 export function App() {
-  const [currentPage, setCurrentPage] = useState<PageId>("orders");
+  const [currentPage, setCurrentPage] = useState<PageId>("stations");
 
   return (
     <Layout currentPage={currentPage} onNavigate={setCurrentPage}>
+      {currentPage === "dashboard" && <DashboardPage />}
       {currentPage === "orders" && <OrdersPage />}
       {currentPage === "stations" && <StationsPage />}
     </Layout>

--- a/manu-gen/frontend/src/features/dashboard/components/DashboardPage.tsx
+++ b/manu-gen/frontend/src/features/dashboard/components/DashboardPage.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { OrderBoard } from "./OrderBoard";
+import { OrderHistory } from "./OrderHistory";
+import { StationDurations } from "./StationDurations";
+import { useOrderBoard } from "../hooks/useOrderBoard";
+
+export function DashboardPage() {
+  const [selectedOrderId, setSelectedOrderId] = useState<number | null>(null);
+  const { data: orders } = useOrderBoard();
+  const selectedOrder = orders?.find((o) => o.id === selectedOrderId) ?? null;
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <h2 className="mb-6 text-xl font-semibold text-gray-900">Dashboard</h2>
+
+      <div className={`mb-8 grid gap-6 ${selectedOrder ? "lg:grid-cols-[1fr_20rem]" : ""}`}>
+        <div className="flex flex-col rounded-lg border bg-white p-6 shadow-sm">
+          <h3 className="mb-4 text-lg font-semibold">Live Order Board</h3>
+          <OrderBoard
+            selectedOrderId={selectedOrderId}
+            onSelectOrder={(order) => setSelectedOrderId(order.id)}
+          />
+        </div>
+
+        {selectedOrder && (
+          <OrderHistory
+            order={selectedOrder}
+            onClose={() => setSelectedOrderId(null)}
+          />
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-white p-6 shadow-sm">
+        <h3 className="mb-4 text-lg font-semibold">Stage Duration Analytics</h3>
+        <StationDurations />
+      </div>
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/features/dashboard/components/OrderBoard.tsx
+++ b/manu-gen/frontend/src/features/dashboard/components/OrderBoard.tsx
@@ -1,0 +1,53 @@
+import { useOrderBoard } from "../hooks/useOrderBoard";
+import { OrderBoardRow } from "./OrderBoardRow";
+import type { BoardOrder } from "../dashboard.types";
+
+interface OrderBoardProps {
+  selectedOrderId: number | null;
+  onSelectOrder: (order: BoardOrder) => void;
+}
+
+export function OrderBoard({ selectedOrderId, onSelectOrder }: OrderBoardProps) {
+  const { data, isLoading, error } = useOrderBoard();
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading order board...</p>;
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-600">Failed to load order board: {error.message}</p>;
+  }
+
+  const orders = data ?? [];
+
+  if (orders.length === 0) {
+    return <p className="text-sm text-gray-500">No orders yet.</p>;
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto" style={{ maxHeight: "200px" }}>
+      <table className="w-full text-sm" role="grid">
+        <thead className="sticky top-0 bg-white">
+          <tr className="border-b text-left text-gray-500">
+            <th className="py-2 pr-4 font-medium">Order</th>
+            <th className="py-2 pr-4 font-medium">Customer</th>
+            <th className="py-2 pr-4 font-medium">Product</th>
+            <th className="py-2 pr-4 font-medium">Current Station</th>
+            <th className="py-2 pr-4 font-medium">Time at Station</th>
+            <th className="py-2 font-medium">Last Seen</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((order) => (
+            <OrderBoardRow
+              key={order.id}
+              order={order}
+              isSelected={selectedOrderId === order.id}
+              onSelect={onSelectOrder}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/features/dashboard/components/OrderBoardRow.tsx
+++ b/manu-gen/frontend/src/features/dashboard/components/OrderBoardRow.tsx
@@ -1,0 +1,73 @@
+import type { BoardOrder } from "../dashboard.types";
+import { formatDuration, parseUtc } from "../dashboard.utils";
+
+interface OrderBoardRowProps {
+  order: BoardOrder;
+  isSelected: boolean;
+  onSelect: (order: BoardOrder) => void;
+}
+
+function formatLastSeen(iso: string): string {
+  const date = parseUtc(iso);
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return isToday ? `${time} today` : date.toLocaleDateString([], { month: "short", day: "numeric" }) + ` ${time}`;
+}
+
+function durationColorClass(seconds: number | null): string {
+  if (seconds === null) return "text-gray-400";
+  if (seconds < 3600) return "text-green-700 bg-green-50";
+  if (seconds < 14400) return "text-yellow-700 bg-yellow-50";
+  return "text-red-700 bg-red-50";
+}
+
+function computeDurationSeconds(lastSeenAt: string | null): number | null {
+  if (!lastSeenAt) return null;
+  return Math.floor((Date.now() - parseUtc(lastSeenAt).getTime()) / 1000);
+}
+
+export function OrderBoardRow({ order, isSelected, onSelect }: OrderBoardRowProps) {
+  const durationSeconds = computeDurationSeconds(order.lastSeenAt);
+  const colorClass = durationColorClass(durationSeconds);
+
+  return (
+    <tr
+      onClick={() => onSelect(order)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(order);
+        }
+      }}
+      tabIndex={0}
+      aria-selected={isSelected}
+      className={`cursor-pointer border-b transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 ${
+        isSelected ? "bg-blue-50" : ""
+      }`}
+    >
+      <td className="py-3 pr-4 font-mono text-sm">{order.orderNumber}</td>
+      <td className="py-3 pr-4 text-sm">{order.customerName}</td>
+      <td className="py-3 pr-4 text-sm">{order.productType}</td>
+      <td className="py-3 pr-4 text-sm">
+        {order.currentStation ? order.currentStation.name : (
+          <span className="italic text-gray-400">(not yet seen)</span>
+        )}
+      </td>
+      <td className="py-3 pr-4 text-sm">
+        {durationSeconds !== null ? (
+          <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${colorClass}`}>
+            {formatDuration(durationSeconds)}
+          </span>
+        ) : (
+          <span className="text-gray-400">--</span>
+        )}
+      </td>
+      <td className="py-3 text-sm">
+        {order.lastSeenAt ? formatLastSeen(order.lastSeenAt) : (
+          <span className="text-gray-400">--</span>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/manu-gen/frontend/src/features/dashboard/components/OrderHistory.tsx
+++ b/manu-gen/frontend/src/features/dashboard/components/OrderHistory.tsx
@@ -1,0 +1,81 @@
+import { useOrderHistory } from "../hooks/useOrderHistory";
+import type { BoardOrder } from "../dashboard.types";
+import { formatDuration, parseUtc } from "../dashboard.utils";
+
+interface OrderHistoryProps {
+  order: BoardOrder;
+  onClose: () => void;
+}
+
+function formatTime(iso: string): string {
+  const date = parseUtc(iso);
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function OrderHistory({ order, onClose }: OrderHistoryProps) {
+  const { data, isLoading, error } = useOrderHistory(order.id);
+
+  return (
+    <div className="rounded-lg border bg-white p-5 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h3 className="font-semibold text-gray-900">
+            {order.orderNumber} — {order.customerName}
+          </h3>
+          <p className="text-sm text-gray-500">{order.productType}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          aria-label="Close order history"
+        >
+          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {isLoading && <p className="text-sm text-gray-500">Loading history...</p>}
+
+      {error && <p className="text-sm text-red-600">Failed to load history: {error.message}</p>}
+
+      {data && data.length === 0 && (
+        <p className="text-sm text-gray-500">No tracking events recorded for this order yet.</p>
+      )}
+
+      {data && data.length > 0 && (
+        <div className="relative overflow-y-auto pl-6" style={{ height: "200px" }}>
+          {data.map((entry, index) => {
+            const isLast = index === data.length - 1;
+            return (
+              <div key={`${entry.station}-${entry.arrivedAt}`} className="relative pb-5 last:pb-0">
+                {!isLast && (
+                  <div className="absolute left-[-16px] top-3 h-full w-px bg-gray-200" />
+                )}
+                <div className="absolute left-[-20px] top-1.5 h-2 w-2 rounded-full border-2 border-blue-500 bg-white" />
+                <div>
+                  <p className="font-medium text-gray-900">{entry.station}</p>
+                  <p className="text-xs text-gray-500">{formatTime(entry.arrivedAt)}</p>
+                  {entry.durationSeconds !== null && (
+                    <p className="mt-0.5 text-xs text-gray-400">
+                      Spent {formatDuration(entry.durationSeconds)}
+                    </p>
+                  )}
+                  {isLast && entry.durationSeconds === null && (
+                    <p className="mt-0.5 text-xs font-medium text-blue-600">Currently here</p>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/features/dashboard/components/StationDurations.tsx
+++ b/manu-gen/frontend/src/features/dashboard/components/StationDurations.tsx
@@ -1,0 +1,45 @@
+import { useDurations } from "../hooks/useDurations";
+import { formatDuration } from "../dashboard.utils";
+
+export function StationDurations() {
+  const { data, isLoading, error } = useDurations();
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading analytics...</p>;
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-600">Failed to load analytics: {error.message}</p>;
+  }
+
+  const durations = data ?? [];
+
+  if (durations.length === 0) {
+    return <p className="text-sm text-gray-500">No stage duration data yet. Durations appear once orders move between stations.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm" role="grid">
+        <thead>
+          <tr className="border-b text-left text-gray-500">
+            <th className="py-2 pr-4 font-medium">Station</th>
+            <th className="py-2 pr-4 font-medium">Avg Duration</th>
+            <th className="py-2 pr-4 font-medium">Max Duration</th>
+            <th className="py-2 font-medium">Orders Passed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {durations.map((d) => (
+            <tr key={d.stationId} className="border-b">
+              <td className="py-3 pr-4 font-medium text-gray-900">{d.stationName}</td>
+              <td className="py-3 pr-4">{formatDuration(d.avgSeconds)}</td>
+              <td className="py-3 pr-4">{formatDuration(d.maxSeconds)}</td>
+              <td className="py-3">{d.orderCount}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/manu-gen/frontend/src/features/dashboard/dashboard.types.ts
+++ b/manu-gen/frontend/src/features/dashboard/dashboard.types.ts
@@ -1,0 +1,24 @@
+export interface BoardOrder {
+  id: number;
+  orderNumber: string;
+  customerName: string;
+  productType: string;
+  trayCode: string;
+  createdAt: string;
+  currentStation: { id: string; name: string } | null;
+  lastSeenAt: string | null;
+}
+
+export interface OrderHistoryEntry {
+  station: string;
+  arrivedAt: string;
+  durationSeconds: number | null;
+}
+
+export interface StationDuration {
+  stationId: string;
+  stationName: string;
+  avgSeconds: number;
+  maxSeconds: number;
+  orderCount: number;
+}

--- a/manu-gen/frontend/src/features/dashboard/dashboard.utils.ts
+++ b/manu-gen/frontend/src/features/dashboard/dashboard.utils.ts
@@ -1,0 +1,10 @@
+export function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+export function parseUtc(raw: string): Date {
+  return new Date(raw.endsWith("Z") ? raw : raw + "Z");
+}

--- a/manu-gen/frontend/src/features/dashboard/hooks/useDurations.ts
+++ b/manu-gen/frontend/src/features/dashboard/hooks/useDurations.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+import type { StationDuration } from "../dashboard.types";
+
+export function useDurations() {
+  return useQuery({
+    queryKey: ["analytics", "durations"],
+    queryFn: () => apiClient.get<StationDuration[]>("/analytics/durations"),
+    refetchInterval: 30_000,
+  });
+}

--- a/manu-gen/frontend/src/features/dashboard/hooks/useOrderBoard.ts
+++ b/manu-gen/frontend/src/features/dashboard/hooks/useOrderBoard.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+import type { BoardOrder } from "../dashboard.types";
+
+export function useOrderBoard() {
+  return useQuery({
+    queryKey: ["orders", "board"],
+    queryFn: () => apiClient.get<BoardOrder[]>("/orders/board"),
+    refetchInterval: (query) => (query.state.error ? 30_000 : 5_000),
+  });
+}

--- a/manu-gen/frontend/src/features/dashboard/hooks/useOrderHistory.ts
+++ b/manu-gen/frontend/src/features/dashboard/hooks/useOrderHistory.ts
@@ -1,0 +1,12 @@
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+import type { OrderHistoryEntry } from "../dashboard.types";
+
+export function useOrderHistory(orderId: number | null) {
+  return useQuery({
+    queryKey: ["orders", orderId, "history"],
+    queryFn: () => apiClient.get<OrderHistoryEntry[]>(`/orders/${orderId}/history`),
+    enabled: orderId !== null,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/manu-gen/frontend/src/shared/components/Sidebar.tsx
+++ b/manu-gen/frontend/src/shared/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-export type PageId = "orders" | "stations";
+export type PageId = "dashboard" | "orders" | "stations";
 
 interface SidebarProps {
   currentPage: PageId;
@@ -8,8 +8,9 @@ interface SidebarProps {
 }
 
 const NAV_ITEMS: { id: PageId; label: string }[] = [
-  { id: "orders", label: "Orders" },
   { id: "stations", label: "Stations" },
+  { id: "orders", label: "Orders" },
+  { id: "dashboard", label: "Dashboard" },
 ];
 
 export function Sidebar({ currentPage, onNavigate }: SidebarProps) {

--- a/manu-gen/frontend/vite.config.ts
+++ b/manu-gen/frontend/vite.config.ts
@@ -6,32 +6,27 @@ import tailwindcss from "@tailwindcss/vite";
 
 const API_TARGET = process.env.API_TARGET ?? "http://localhost:3000";
 
+function apiProxy() {
+  return {
+    target: API_TARGET,
+    configure: (proxy: import("http-proxy").Server) => {
+      proxy.on("proxyReq", (_, req) => {
+        console.log(`[proxy] → ${req.method} ${req.url}`);
+      });
+      proxy.on("proxyRes", (res, req) => {
+        console.log(`[proxy] ← ${res.statusCode} ${req.method} ${req.url}`);
+      });
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {
-      "/orders": {
-        target: API_TARGET,
-        configure: (proxy) => {
-          proxy.on("proxyReq", (_, req) => {
-            console.log(`[proxy] → ${req.method} ${req.url}`);
-          });
-          proxy.on("proxyRes", (res, req) => {
-            console.log(`[proxy] ← ${res.statusCode} ${req.method} ${req.url}`);
-          });
-        },
-      },
-      "/stations": {
-        target: API_TARGET,
-        configure: (proxy) => {
-          proxy.on("proxyReq", (_, req) => {
-            console.log(`[proxy] → ${req.method} ${req.url}`);
-          });
-          proxy.on("proxyRes", (res, req) => {
-            console.log(`[proxy] ← ${res.statusCode} ${req.method} ${req.url}`);
-          });
-        },
-      },
+      "/orders": apiProxy(),
+      "/stations": apiProxy(),
+      "/analytics": apiProxy(),
     },
   },
   test: {

--- a/manu-gen/frontend/vite.config.ts
+++ b/manu-gen/frontend/vite.config.ts
@@ -1,20 +1,21 @@
 // vitest/config re-exports Vite's defineConfig augmented with the `test` key.
 // This is the documented single-file config pattern for Vite + Vitest.
 import { defineConfig } from "vitest/config";
+import type { ProxyOptions } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 const API_TARGET = process.env.API_TARGET ?? "http://localhost:3000";
 
-function apiProxy() {
+function apiProxy(): ProxyOptions {
   return {
     target: API_TARGET,
-    configure: (proxy: import("http-proxy").Server) => {
-      proxy.on("proxyReq", (_, req) => {
+    configure: (proxy) => {
+      proxy.on("proxyReq", (_proxyReq, req) => {
         console.log(`[proxy] → ${req.method} ${req.url}`);
       });
-      proxy.on("proxyRes", (res, req) => {
-        console.log(`[proxy] ← ${res.statusCode} ${req.method} ${req.url}`);
+      proxy.on("proxyRes", (proxyRes, req) => {
+        console.log(`[proxy] ← ${proxyRes.statusCode} ${req.method} ${req.url}`);
       });
     },
   };


### PR DESCRIPTION
## Summary

- Adds a Reporting Dashboard page to give operators a real-time view of where every order is in the factory and how long each stage typically takes. Addresses the need for live visibility without manual querying.

## Changes

**Backend**
- `GET /orders/board` — latest tracking event per tray using `ROW_NUMBER()` window function; sorted by wait time desc, unseen orders last
- `GET /orders/:id/history` — full per-order event timeline with `LEAD()`-computed dwell durations
- `GET /analytics/durations` — per-station avg/max throughput aggregated over completed visits
- `toIso()` helper in `orders.schema` strips trailing `Z` before normalising SQLite space-separated datetimes, preventing double-Z parse errors with Z-suffixed eye-scanner timestamps

**Frontend**
- Live Order Board table polling every 5 s (30 s backoff on error); duration computed client-side from `lastSeenAt`
- Order History side panel with fixed height, scroll, and `keepPreviousData` to prevent height flicker on row switch
- Stage Duration Analytics table refreshing every 30 s
- Shared `formatDuration` / `parseUtc` utilities in `dashboard.utils.ts`
- Vite proxy extended to cover `/analytics`
- Dashboard added to sidebar navigation (after Stations and Orders)

**Tests**
- `orders.dashboard.test.ts` and `analytics.service.test.ts` with Z-suffix timestamp cases covering the double-Z regression path
- `vitest.config.ts` with `fileParallelism: false` — all test files share one SQLite DB; parallel execution caused lock and FK constraint failures
- Reset `sqlite_sequence` for `tracking_events` in events `beforeEach` hooks to keep autoincrement IDs deterministic

## Test plan

- [ ] `cd manu-gen/backend && npm test` — all 112 tests pass
- [ ] Start the app and navigate to the Dashboard page
- [ ] Verify the Live Order Board updates automatically after scanning a tray
- [ ] Click a board row and confirm the Order History panel appears with correct dwell times and scrolls when there are many events
- [ ] Verify the Stage Duration Analytics table populates after at least two scans of the same order

## Notes

Pagination for `/orders/board` and `/analytics/durations` is a known follow-up; both endpoints are unbounded today and should be addressed before the dataset grows large.

Made with [Cursor](https://cursor.com)