### PR TITLE
chore: add script to clean Docker DB and document local/Docker clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ To stop and remove containers:
 docker-compose down
 ```
 
-To also wipe the SQLite volume:
+To clean the database (e.g. clear all orders and events) while keeping the stack running:
+
+```bash
+./scripts/clean-docker-db.sh
+```
+
+This removes the DB files inside the backend container and restarts the backend so it starts with an empty database. To remove the volume entirely (e.g. before `docker-compose up`), use:
 
 ```bash
 docker-compose down -v
@@ -53,6 +59,8 @@ docker-compose down -v
 cd manu-gen/backend && yarn install && yarn dev
 cd manu-gen/frontend && yarn install && yarn dev
 ```
+
+To clean the local database, stop the backend then run `cd manu-gen/backend && yarn db:clean` and start the backend again.
 
 ## Architecture
 

--- a/scripts/clean-docker-db.sh
+++ b/scripts/clean-docker-db.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")/.."
+echo "Removing SQLite DB files in backend container..."
+docker-compose exec backend sh -c 'rm -f /data/manu-gen.db /data/manu-gen.db-wal /data/manu-gen.db-shm'
+echo "Restarting backend to create fresh DB..."
+docker-compose restart backend
+echo "Done. Backend is running with an empty database."


### PR DESCRIPTION
## Summary

- Adds a way to reset the database when running the app in Docker, and documents both Docker and local DB clean steps in the README.

## Changes

- **`scripts/clean-docker-db.sh`** — Removes SQLite DB files inside the backend container (`/data/manu-gen.db` and WAL/shm) and restarts the backend so it starts with an empty database. Run from repo root while `docker-compose up` is running.
- **README** — Documents Docker clean: `./scripts/clean-docker-db.sh` for in-place reset; `docker-compose down -v` for removing the volume. Also adds a note for local: stop backend, `yarn db:clean` in `manu-gen/backend`, then start again.

## Test plan

- [ ] With `docker-compose up`, create some orders/events, then run `./scripts/clean-docker-db.sh`.
- [ ] Confirm backend restarts and the app shows no orders; new orders can be created.

Made with [Cursor](https://cursor.com)