### PR TITLE
feat(pipeline-capacity): add pipeline capacity limits, auto-allocation, and job/order management

### DIFF
--- a/manu-gen/backend/src/db.ts
+++ b/manu-gen/backend/src/db.ts
@@ -27,11 +27,15 @@ const SCHEMA: string[] = [
   )`,
 
   `CREATE TABLE IF NOT EXISTS pipelines (
-    id          TEXT PRIMARY KEY,
-    name        TEXT NOT NULL,
-    description TEXT NOT NULL DEFAULT '',
-    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    description  TEXT NOT NULL DEFAULT '',
+    product_type TEXT NOT NULL DEFAULT '',
+    created_at   TEXT NOT NULL DEFAULT (datetime('now'))
   )`,
+
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_pipelines_product_type
+   ON pipelines(product_type) WHERE product_type != ''`,
 
   `CREATE TABLE IF NOT EXISTS pipeline_steps (
     id                   INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -39,6 +43,7 @@ const SCHEMA: string[] = [
     station_id           TEXT NOT NULL REFERENCES stations(id),
     position             INTEGER NOT NULL CHECK (position > 0),
     max_duration_seconds INTEGER,
+    max_capacity         INTEGER,
     UNIQUE(pipeline_id, position),
     UNIQUE(pipeline_id, station_id)
   )`,
@@ -51,7 +56,8 @@ const SCHEMA: string[] = [
     notes        TEXT DEFAULT '',
     tray_code    TEXT NOT NULL UNIQUE,
     created_at   TEXT NOT NULL DEFAULT (datetime('now')),
-    pipeline_id  TEXT NOT NULL REFERENCES pipelines(id)
+    pipeline_id  TEXT NOT NULL REFERENCES pipelines(id),
+    status       TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','in_progress','completed'))
   )`,
 
   `CREATE TABLE IF NOT EXISTS customer_orders (

--- a/manu-gen/backend/src/features/analytics/analytics.controller.ts
+++ b/manu-gen/backend/src/features/analytics/analytics.controller.ts
@@ -29,3 +29,12 @@ analyticsRouter.get("/activity", (req, res, next) => {
     next(err);
   }
 });
+
+analyticsRouter.get("/order-metrics", (req, res, next) => {
+  try {
+    const metrics = analyticsService.getOrderMetrics();
+    res.json(metrics);
+  } catch (err) {
+    next(err);
+  }
+});

--- a/manu-gen/backend/src/features/analytics/analytics.schema.ts
+++ b/manu-gen/backend/src/features/analytics/analytics.schema.ts
@@ -58,3 +58,17 @@ export interface StationActivity {
   stationName: string;
   buckets: HourlyBucket[];
 }
+
+export interface OrderMetrics {
+  totalOrders: number;
+  fulfilledOrders: number;
+  avgJobsPerOrder: number;
+  byProductType: ProductTypeMetric[];
+}
+
+export interface ProductTypeMetric {
+  productType: string;
+  totalQuantity: number;
+  fulfilledQuantity: number;
+  jobCount: number;
+}

--- a/manu-gen/backend/src/features/analytics/analytics.service.test.ts
+++ b/manu-gen/backend/src/features/analytics/analytics.service.test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
   const station = stationsService.createStation({ name: "Seed Station" });
   const pipeline = pipelinesService.createPipeline({
     name: "Seed Pipeline",
+    productType: "Widget",
     steps: [{ stationId: station.id, maxDurationSeconds: null }],
   });
   testPipelineId = pipeline.id;
@@ -30,7 +31,7 @@ beforeEach(() => {
 
 function createTestJob(overrides?: Partial<{ productType: string; quantity: number }>) {
   return jobsService.createJob({
-    productType: overrides?.productType ?? "X",
+    productType: overrides?.productType ?? "Widget",
     quantity: overrides?.quantity ?? 1,
     pipelineId: testPipelineId,
   });
@@ -57,7 +58,7 @@ describe("getStationDurations", () => {
 
   it("should compute avg and max durations across orders", () => {
     const order1 = createTestJob();
-    const order2 = createTestJob({ productType: "Y" });
+    const order2 = createTestJob({ productType: "Widget" });
     const station1 = stationsService.createStation({ name: "Moulding" });
     const station2 = stationsService.createStation({ name: "Drying Room" });
 

--- a/manu-gen/backend/src/features/analytics/analytics.service.ts
+++ b/manu-gen/backend/src/features/analytics/analytics.service.ts
@@ -5,6 +5,8 @@ import type {
   DashboardSummary,
   HourlyActivityRow,
   StationActivity,
+  OrderMetrics,
+  ProductTypeMetric,
 } from "./analytics.schema.js";
 import { toStationDuration } from "./analytics.schema.js";
 import { parseUtcMs } from "../../shared/datetime.js";
@@ -273,4 +275,69 @@ export function getHourlyActivity(): StationActivity[] {
   }
 
   return result;
+}
+
+const stmtOrderCounts = db.prepare(`
+  SELECT
+    COUNT(*) AS total,
+    SUM(CASE WHEN status = 'fulfilled' THEN 1 ELSE 0 END) AS fulfilled
+  FROM customer_orders
+`);
+
+const stmtAvgJobsPerOrder = db.prepare(`
+  SELECT AVG(job_cnt) AS avg_jobs FROM (
+    SELECT co.id, COUNT(DISTINCT ja.job_id) AS job_cnt
+    FROM customer_orders co
+    JOIN order_lines ol ON ol.customer_order_id = co.id
+    JOIN job_allocations ja ON ja.order_line_id = ol.id
+    GROUP BY co.id
+  )
+`);
+
+const stmtProductTypeMetrics = db.prepare(`
+  SELECT
+    ol.product_type,
+    SUM(ol.quantity) AS total_quantity,
+    SUM(COALESCE((
+      SELECT SUM(ja2.quantity) FROM job_allocations ja2
+      JOIN jobs j2 ON j2.id = ja2.job_id
+      WHERE ja2.order_line_id = ol.id AND j2.status = 'completed'
+    ), 0)) AS fulfilled_quantity,
+    COUNT(DISTINCT ja.job_id) AS job_count
+  FROM order_lines ol
+  LEFT JOIN job_allocations ja ON ja.order_line_id = ol.id
+  GROUP BY ol.product_type
+  ORDER BY total_quantity DESC
+`);
+
+interface OrderCountRow {
+  total: number;
+  fulfilled: number;
+}
+
+interface ProductTypeMetricRow {
+  product_type: string;
+  total_quantity: number;
+  fulfilled_quantity: number;
+  job_count: number;
+}
+
+export function getOrderMetrics(): OrderMetrics {
+  const counts = stmtOrderCounts.get() as OrderCountRow;
+  const avgJobs = stmtAvgJobsPerOrder.get() as { avg_jobs: number | null };
+  const productRows = stmtProductTypeMetrics.all() as ProductTypeMetricRow[];
+
+  const byProductType: ProductTypeMetric[] = productRows.map((r) => ({
+    productType: r.product_type,
+    totalQuantity: r.total_quantity,
+    fulfilledQuantity: r.fulfilled_quantity,
+    jobCount: r.job_count,
+  }));
+
+  return {
+    totalOrders: counts.total,
+    fulfilledOrders: counts.fulfilled,
+    avgJobsPerOrder: avgJobs.avg_jobs !== null ? Math.round(avgJobs.avg_jobs * 10) / 10 : 0,
+    byProductType,
+  };
 }

--- a/manu-gen/backend/src/features/customer-orders/customer-orders.schema.ts
+++ b/manu-gen/backend/src/features/customer-orders/customer-orders.schema.ts
@@ -14,7 +14,7 @@ export const createCustomerOrderSchema = z.object({
     .min(1, "at least one line is required"),
 });
 
-export type CreateCustomerOrderInput = z.infer<typeof createCustomerOrderSchema>;
+export type CreateCustomerOrderInput = z.input<typeof createCustomerOrderSchema>;
 
 export const updateCustomerOrderSchema = z.object({
   customerName: z.string().min(1).optional(),

--- a/manu-gen/backend/src/features/customer-orders/customer-orders.service.test.ts
+++ b/manu-gen/backend/src/features/customer-orders/customer-orders.service.test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
   stationId = stationsService.createStation({ name: "Test Station" }).id;
   pipelineId = pipelinesService.createPipeline({
     name: "Pipeline A",
+    productType: "Widget",
     steps: [{ stationId, maxDurationSeconds: 120 }],
   }).id;
 });
@@ -203,7 +204,7 @@ describe("deleteCustomerOrder", () => {
     );
   });
 
-  it("should throw 409 when order has allocations", () => {
+  it("should cascade-delete allocations when order is deleted", () => {
     const order = service.createCustomerOrder({
       customerName: "Acme",
       lines: [{ productType: "Widget", quantity: 10 }],
@@ -211,9 +212,12 @@ describe("deleteCustomerOrder", () => {
     const job = jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
     jobsService.addAllocation(job.id, { orderLineId: order.lines[0].id, quantity: 5 });
 
-    expect(() => service.deleteCustomerOrder(order.id)).toThrow(
-      expect.objectContaining({ statusCode: 409 }),
+    service.deleteCustomerOrder(order.id);
+
+    expect(() => service.getCustomerOrderById(order.id)).toThrow(
+      expect.objectContaining({ statusCode: 404 }),
     );
+    expect(jobsService.listAllocations(job.id)).toHaveLength(0);
   });
 
   it("should throw 404 when order does not exist", () => {
@@ -221,115 +225,155 @@ describe("deleteCustomerOrder", () => {
       expect.objectContaining({ statusCode: 404 }),
     );
   });
+
+  it("should reduce shared job quantity when order is deleted", () => {
+    const job = jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
+
+    const order1 = service.createCustomerOrder({
+      customerName: "A",
+      lines: [{ productType: "Widget", quantity: 5 }],
+    });
+    jobsService.addAllocation(job.id, { orderLineId: order1.lines[0].id, quantity: 5 });
+
+    const order2 = service.createCustomerOrder({
+      customerName: "B",
+      lines: [{ productType: "Widget", quantity: 3 }],
+    });
+    jobsService.addAllocation(job.id, { orderLineId: order2.lines[0].id, quantity: 3 });
+
+    service.deleteCustomerOrder(order1.id);
+
+    const updated = jobsService.getJobById(job.id);
+    expect(updated.quantity).toBe(15);
+    expect(jobsService.listAllocations(job.id)).toHaveLength(1);
+  });
+
+  it("should delete exclusively-serving jobs when order is deleted", () => {
+    // Need a pipeline with capacity for auto-allocation to create jobs
+    const capPipeline = pipelinesService.createPipeline({
+      name: "Cap Pipeline",
+      productType: "Cap",
+      steps: [{ stationId, maxDurationSeconds: 60, maxCapacity: 10 }],
+    });
+
+    const order = service.createCustomerOrder({
+      customerName: "Solo",
+      lines: [{ productType: "Cap", quantity: 15 }],
+    });
+    const autoJobIds = order.lines[0].allocations.map((a) => a.jobId);
+    expect(autoJobIds.length).toBe(2);
+
+    service.deleteCustomerOrder(order.id);
+
+    for (const jobId of autoJobIds) {
+      expect(() => jobsService.getJobById(jobId)).toThrow(
+        expect.objectContaining({ statusCode: 404 }),
+      );
+    }
+  });
 });
 
 describe("auto-allocation on order creation", () => {
-  it("should auto-allocate matching jobs to order lines", () => {
-    jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
+  let capacityPipelineId: string;
 
+  beforeEach(() => {
+    // Create a pipeline with capacity configured
+    capacityPipelineId = pipelinesService.createPipeline({
+      name: "Capacity Pipeline",
+      productType: "Crone",
+      steps: [{ stationId, maxDurationSeconds: 120, maxCapacity: 10 }],
+    }).id;
+  });
+
+  it("should auto-create jobs and allocate when pipeline has capacity", () => {
     const order = service.createCustomerOrder({
       customerName: "Acme",
-      lines: [{ productType: "Widget", quantity: 10 }],
+      lines: [{ productType: "Crone", quantity: 8 }],
     });
 
-    expect(order.lines[0].allocatedQuantity).toBe(10);
+    expect(order.lines[0].allocatedQuantity).toBe(8);
     expect(order.lines[0].allocations).toHaveLength(1);
-    expect(order.lines[0].allocations[0].jobNumber).toBe("JOB-0001");
-    expect(order.lines[0].allocations[0].quantity).toBe(10);
     expect(order.allocationPct).toBe(100);
-    expect(order.fulfillmentPct).toBe(0);
   });
 
-  it("should not allocate more than the line needs", () => {
-    jobsService.createJob({ productType: "Widget", quantity: 50, pipelineId });
+  it("should create multiple jobs when quantity exceeds capacity", () => {
+    const order = service.createCustomerOrder({
+      customerName: "Acme",
+      lines: [{ productType: "Crone", quantity: 25 }],
+    });
+
+    expect(order.lines[0].allocatedQuantity).toBe(25);
+    expect(order.lines[0].allocations).toHaveLength(3); // 10 + 10 + 5
+    expect(order.lines[0].allocations[0].quantity).toBe(10);
+    expect(order.lines[0].allocations[1].quantity).toBe(10);
+    expect(order.lines[0].allocations[2].quantity).toBe(5);
+    expect(order.allocationPct).toBe(100);
+  });
+
+  it("should pack into existing pending jobs before creating new ones", () => {
+    // Create a pending job with quantity 3, no allocations → capacity(10) - allocated(0) = 10 free
+    jobsService.createJob({ productType: "Crone", quantity: 3, pipelineId: capacityPipelineId });
 
     const order = service.createCustomerOrder({
       customerName: "Acme",
-      lines: [{ productType: "Widget", quantity: 5 }],
+      lines: [{ productType: "Crone", quantity: 15 }],
     });
 
-    expect(order.lines[0].allocatedQuantity).toBe(5);
-    expect(order.lines[0].allocations[0].quantity).toBe(5);
-  });
-
-  it("should spread across multiple jobs in FIFO order", () => {
-    jobsService.createJob({ productType: "Widget", quantity: 6, pipelineId });
-    jobsService.createJob({ productType: "Widget", quantity: 10, pipelineId });
-
-    const order = service.createCustomerOrder({
-      customerName: "Acme",
-      lines: [{ productType: "Widget", quantity: 12 }],
-    });
-
+    // 10 packed into existing job (grown from 3→10), then 5 in a new job
+    expect(order.lines[0].allocatedQuantity).toBe(15);
     expect(order.lines[0].allocations).toHaveLength(2);
-    expect(order.lines[0].allocations[0].jobNumber).toBe("JOB-0001");
-    expect(order.lines[0].allocations[0].quantity).toBe(6);
-    expect(order.lines[0].allocations[1].jobNumber).toBe("JOB-0002");
-    expect(order.lines[0].allocations[1].quantity).toBe(6);
-    expect(order.lines[0].allocatedQuantity).toBe(12);
+    expect(order.lines[0].allocations[0].quantity).toBe(10);
+    expect(order.lines[0].allocations[1].quantity).toBe(5);
   });
 
-  it("should partially allocate when job capacity is insufficient", () => {
-    jobsService.createJob({ productType: "Widget", quantity: 3, pipelineId });
-
+  it("should not allocate when no pipeline matches the product type", () => {
     const order = service.createCustomerOrder({
       customerName: "Acme",
-      lines: [{ productType: "Widget", quantity: 10 }],
-    });
-
-    expect(order.lines[0].allocatedQuantity).toBe(3);
-    expect(order.lines[0].allocations).toHaveLength(1);
-    expect(order.allocationPct).toBe(30);
-    expect(order.fulfillmentPct).toBe(0);
-  });
-
-  it("should leave allocations empty when no matching jobs exist", () => {
-    jobsService.createJob({ productType: "Gadget", quantity: 50, pipelineId });
-
-    const order = service.createCustomerOrder({
-      customerName: "Acme",
-      lines: [{ productType: "Widget", quantity: 10 }],
+      lines: [{ productType: "Unknown", quantity: 10 }],
     });
 
     expect(order.lines[0].allocatedQuantity).toBe(0);
     expect(order.lines[0].allocations).toEqual([]);
   });
 
-  it("should respect already-allocated capacity from prior orders", () => {
-    jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
+  it("should not pack into in_progress jobs", () => {
+    const job = jobsService.createJob({ productType: "Crone", quantity: 3, pipelineId: capacityPipelineId });
+    // Simulate starting the job by directly updating status
+    db.prepare("UPDATE jobs SET status = 'in_progress' WHERE id = ?").run(job.id);
 
-    service.createCustomerOrder({
-      customerName: "First",
-      lines: [{ productType: "Widget", quantity: 15 }],
+    const order = service.createCustomerOrder({
+      customerName: "Acme",
+      lines: [{ productType: "Crone", quantity: 5 }],
     });
 
-    const second = service.createCustomerOrder({
-      customerName: "Second",
-      lines: [{ productType: "Widget", quantity: 10 }],
-    });
-
-    expect(second.lines[0].allocatedQuantity).toBe(5);
-    expect(second.lines[0].allocations[0].quantity).toBe(5);
+    // Should create a new job, not pack into the in_progress one
+    expect(order.lines[0].allocatedQuantity).toBe(5);
+    expect(order.lines[0].allocations).toHaveLength(1);
+    // The allocation should NOT be on the in_progress job
+    expect(order.lines[0].allocations[0].jobId).not.toBe(job.id);
   });
 
-  it("should auto-allocate each line independently", () => {
-    jobsService.createJob({ productType: "Widget", quantity: 10, pipelineId });
-    jobsService.createJob({ productType: "Gadget", quantity: 20, pipelineId });
+  it("should handle multiple lines with different product types", () => {
+    // Add another pipeline for a different product
+    pipelinesService.createPipeline({
+      name: "Gadget Pipeline",
+      productType: "Gadget",
+      steps: [{ stationId, maxDurationSeconds: 60, maxCapacity: 5 }],
+    });
 
     const order = service.createCustomerOrder({
       customerName: "Acme",
       lines: [
-        { productType: "Widget", quantity: 5 },
-        { productType: "Gadget", quantity: 8 },
+        { productType: "Crone", quantity: 8 },
+        { productType: "Gadget", quantity: 12 },
       ],
     });
 
-    expect(order.lines[0].allocatedQuantity).toBe(5);
-    expect(order.lines[0].allocations[0].jobNumber).toBe("JOB-0001");
-    expect(order.lines[1].allocatedQuantity).toBe(8);
-    expect(order.lines[1].allocations[0].jobNumber).toBe("JOB-0002");
+    expect(order.lines[0].allocatedQuantity).toBe(8);
+    expect(order.lines[0].allocations).toHaveLength(1);
+    expect(order.lines[1].allocatedQuantity).toBe(12);
+    expect(order.lines[1].allocations).toHaveLength(3); // 5 + 5 + 2
     expect(order.allocationPct).toBe(100);
-    expect(order.fulfillmentPct).toBe(0);
   });
 });
 

--- a/manu-gen/backend/src/features/customer-orders/customer-orders.service.ts
+++ b/manu-gen/backend/src/features/customer-orders/customer-orders.service.ts
@@ -13,6 +13,8 @@ import type {
 } from "./customer-orders.schema.js";
 import { toCustomerOrderSummary } from "./customer-orders.schema.js";
 import { stmtInsertAllocation } from "../../shared/allocation-statements.js";
+import { getPipelineByProductType } from "../pipelines/pipelines.service.js";
+import { createJobRaw, packIntoJob, deleteJob } from "../jobs/jobs.service.js";
 
 function formatOrderNumber(id: number): string {
   return `CO-${String(id).padStart(4, "0")}`;
@@ -68,15 +70,7 @@ const stmtFulfilledCountByLine = db.prepare(`
   SELECT COALESCE(SUM(ja.quantity), 0) AS total
   FROM job_allocations ja
   JOIN jobs j ON j.id = ja.job_id
-  WHERE ja.order_line_id = ?
-    AND (
-      SELECT COUNT(DISTINCT te.station_id)
-      FROM tracking_events te
-      WHERE te.tray_code = j.tray_code AND te.phase = 'departed'
-    ) >= (
-      SELECT COUNT(*) FROM pipeline_steps ps WHERE ps.pipeline_id = j.pipeline_id
-    )
-    AND (SELECT COUNT(*) FROM pipeline_steps ps2 WHERE ps2.pipeline_id = j.pipeline_id) > 0
+  WHERE ja.order_line_id = ? AND j.status = 'completed'
 `);
 
 const stmtAllocsByLine = db.prepare(`
@@ -87,21 +81,20 @@ const stmtAllocsByLine = db.prepare(`
   ORDER BY ja.id
 `);
 
-const stmtAvailableJobs = db.prepare(`
-  SELECT j.id, j.quantity - COALESCE(SUM(ja.quantity), 0) AS available
+const stmtPendingJobs = db.prepare(`
+  SELECT j.id, j.quantity, COALESCE(SUM(ja.quantity), 0) AS allocated
   FROM jobs j
   LEFT JOIN job_allocations ja ON ja.job_id = j.id
-  WHERE j.product_type = ?
+  WHERE j.pipeline_id = ? AND j.status = 'pending'
   GROUP BY j.id
-  HAVING available > 0
   ORDER BY j.id ASC
 `);
 
-const stmtAllocCountByOrder = db.prepare(`
-  SELECT COUNT(*) AS cnt FROM job_allocations ja
-  JOIN order_lines ol ON ol.id = ja.order_line_id
-  WHERE ol.customer_order_id = ?
-`);
+interface PendingJobRow {
+  id: number;
+  quantity: number;
+  allocated: number;
+}
 
 interface AllocRow {
   id: number;
@@ -142,24 +135,36 @@ function computePcts(lines: OrderLine[]): { allocationPct: number; fulfillmentPc
   };
 }
 
-interface AvailableJobRow {
-  id: number;
-  available: number;
-}
+function autoCreateAndAllocate(
+  orderLineId: number,
+  productType: string,
+  quantityNeeded: number,
+): void {
+  const pipeline = getPipelineByProductType(productType);
+  if (!pipeline) return;
 
-function autoAllocateLine(orderLineId: number, productType: string, quantityNeeded: number): void {
-  const jobs = stmtAvailableJobs.all(productType) as AvailableJobRow[];
+  const capacity = pipeline.effectiveCapacity;
+  if (!capacity || capacity <= 0) return;
+
   let remaining = quantityNeeded;
 
-  for (const job of jobs) {
+  const pendingJobs = stmtPendingJobs.all(pipeline.id) as PendingJobRow[];
+  for (const pj of pendingJobs) {
     if (remaining <= 0) break;
-    const toAllocate = Math.min(job.available, remaining);
-    stmtInsertAllocation.run({
-      order_line_id: orderLineId,
-      job_id: job.id,
-      quantity: toAllocate,
-    });
-    remaining -= toAllocate;
+    const space = capacity - pj.allocated;
+    if (space <= 0) continue;
+    const toAdd = Math.min(space, remaining);
+    const growBy = Math.max(0, (pj.allocated + toAdd) - pj.quantity);
+    if (growBy > 0) packIntoJob(pj.id, growBy);
+    stmtInsertAllocation.run({ order_line_id: orderLineId, job_id: pj.id, quantity: toAdd });
+    remaining -= toAdd;
+  }
+
+  while (remaining > 0) {
+    const batch = Math.min(capacity, remaining);
+    const jobId = createJobRaw(productType, batch, pipeline.id);
+    stmtInsertAllocation.run({ order_line_id: orderLineId, job_id: jobId, quantity: batch });
+    remaining -= batch;
   }
 }
 
@@ -180,7 +185,7 @@ const createOrderTx = db.transaction((input: CreateCustomerOrderInput): number =
       product_type: line.productType,
       quantity: line.quantity,
     });
-    autoAllocateLine(
+    autoCreateAndAllocate(
       Number(result.lastInsertRowid),
       line.productType,
       line.quantity,
@@ -246,18 +251,64 @@ export function updateCustomerOrder(
   return getCustomerOrderById(id);
 }
 
+const stmtAllocsByOrder = db.prepare(`
+  SELECT ja.job_id, ja.quantity
+  FROM job_allocations ja
+  JOIN order_lines ol ON ol.id = ja.order_line_id
+  WHERE ol.customer_order_id = ?
+`);
+
+const stmtOtherAllocCount = db.prepare(`
+  SELECT COUNT(*) AS cnt FROM job_allocations
+  WHERE job_id = ? AND order_line_id NOT IN (
+    SELECT id FROM order_lines WHERE customer_order_id = ?
+  )
+`);
+
+const stmtDeleteAllocsByOrder = db.prepare(`
+  DELETE FROM job_allocations WHERE order_line_id IN (
+    SELECT id FROM order_lines WHERE customer_order_id = ?
+  )
+`);
+
+const stmtUpdateJobQty = db.prepare(`UPDATE jobs SET quantity = quantity - @delta WHERE id = @id`);
+const stmtJobQuantity = db.prepare(`SELECT quantity FROM jobs WHERE id = ?`);
+
 const deleteOrderTx = db.transaction((id: number): void => {
   const existing = stmtGetById.get(id) as CustomerOrderRow | undefined;
   if (!existing) {
     throw new AppError(404, `Customer order with id ${id} not found`);
   }
-  const { cnt } = stmtAllocCountByOrder.get(id) as { cnt: number };
-  if (cnt > 0) {
-    throw new AppError(
-      409,
-      `Cannot delete order "${existing.order_number}": ${cnt} job allocation(s) exist`,
-    );
+
+  const allocs = stmtAllocsByOrder.all(id) as { job_id: number; quantity: number }[];
+
+  const jobDeltas = new Map<number, number>();
+  for (const a of allocs) {
+    jobDeltas.set(a.job_id, (jobDeltas.get(a.job_id) ?? 0) + a.quantity);
   }
+
+  // Decide fate of each job BEFORE deleting allocations
+  const jobsToDelete = new Set<number>();
+  const jobsToShrink = new Map<number, number>();
+  for (const [jobId, delta] of jobDeltas) {
+    const { cnt } = stmtOtherAllocCount.get(jobId, id) as { cnt: number };
+    if (cnt === 0) {
+      jobsToDelete.add(jobId);
+    } else {
+      const row = stmtJobQuantity.get(jobId) as { quantity: number };
+      jobsToShrink.set(jobId, Math.min(delta, row.quantity - 1));
+    }
+  }
+
+  stmtDeleteAllocsByOrder.run(id);
+
+  for (const jobId of jobsToDelete) {
+    deleteJob(jobId);
+  }
+  for (const [jobId, safeDelta] of jobsToShrink) {
+    if (safeDelta > 0) stmtUpdateJobQty.run({ id: jobId, delta: safeDelta });
+  }
+
   stmtDeleteLines.run(id);
   stmtDelete.run(id);
 });

--- a/manu-gen/backend/src/features/events/events.service.ts
+++ b/manu-gen/backend/src/features/events/events.service.ts
@@ -2,6 +2,7 @@ import db from "../../db.js";
 import { AppError } from "../../shared/errors/app-error.js";
 import type { CreateEventInput, TrackingEvent, TrackingEventRow } from "./events.schema.js";
 import { toTrackingEvent } from "./events.schema.js";
+import { onTrackingEvent } from "../jobs/jobs.service.js";
 
 const EVENT_COLUMNS = "id, tray_code, station_id, eye_id, captured_at, received_at, phase";
 
@@ -24,7 +25,9 @@ export function createEvent(input: CreateEventInput): TrackingEvent {
     captured_at: input.capturedAt,
     phase: input.phase ?? "scan",
   });
-  return getEventById(Number(result.lastInsertRowid));
+  const event = getEventById(Number(result.lastInsertRowid));
+  onTrackingEvent(input.trayCode);
+  return event;
 }
 
 export function getEventById(id: number): TrackingEvent {

--- a/manu-gen/backend/src/features/jobs/jobs.controller.test.ts
+++ b/manu-gen/backend/src/features/jobs/jobs.controller.test.ts
@@ -19,6 +19,7 @@ beforeEach(async () => {
   const stationRes = await request(app).post("/stations").send({ name: "Test Station" });
   const pipelineRes = await request(app).post("/pipelines").send({
     name: "Test Pipeline",
+    productType: "Widget",
     steps: [{ stationId: stationRes.body.id, maxDurationSeconds: 120 }],
   });
   pipelineId = pipelineRes.body.id;
@@ -164,7 +165,7 @@ describe("allocation endpoints", () => {
   async function createOrderWithLine(): Promise<{ orderId: number; lineId: number }> {
     const res = await request(app).post("/customer-orders").send({
       customerName: "Acme",
-      lines: [{ productType: "Sprocket", quantity: 10 }],
+      lines: [{ productType: "Widget", quantity: 10 }],
     });
     return { orderId: res.body.id, lineId: res.body.lines[0].id };
   }
@@ -172,7 +173,7 @@ describe("allocation endpoints", () => {
   describe("POST /jobs/:id/allocations", () => {
     it("should create an allocation and return 201", async () => {
       const { lineId } = await createOrderWithLine();
-      const job = await request(app).post("/jobs").send({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 20, pipelineId });
 
       const res = await request(app)
         .post(`/jobs/${job.body.id}/allocations`)
@@ -185,7 +186,7 @@ describe("allocation endpoints", () => {
     });
 
     it("should return 400 when orderLineId is missing", async () => {
-      const job = await request(app).post("/jobs").send({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 20, pipelineId });
       const res = await request(app)
         .post(`/jobs/${job.body.id}/allocations`)
         .send({ quantity: 5 });
@@ -195,7 +196,7 @@ describe("allocation endpoints", () => {
 
     it("should return 422 when allocation exceeds job capacity", async () => {
       const { lineId } = await createOrderWithLine();
-      const job = await request(app).post("/jobs").send({ productType: "Sprocket", quantity: 3, pipelineId });
+      const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 3, pipelineId });
 
       const res = await request(app)
         .post(`/jobs/${job.body.id}/allocations`)
@@ -224,7 +225,7 @@ describe("allocation endpoints", () => {
   describe("GET /jobs/:id/allocations", () => {
     it("should list allocations for a job", async () => {
       const { lineId } = await createOrderWithLine();
-      const job = await request(app).post("/jobs").send({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 20, pipelineId });
 
       await request(app)
         .post(`/jobs/${job.body.id}/allocations`)
@@ -240,7 +241,7 @@ describe("allocation endpoints", () => {
   describe("DELETE /jobs/:id/allocations/:allocationId", () => {
     it("should delete an allocation and return 204", async () => {
       const { lineId } = await createOrderWithLine();
-      const job = await request(app).post("/jobs").send({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 20, pipelineId });
 
       const allocRes = await request(app)
         .post(`/jobs/${job.body.id}/allocations`)
@@ -251,9 +252,42 @@ describe("allocation endpoints", () => {
     });
 
     it("should return 404 for non-existent allocation", async () => {
-      const job = await request(app).post("/jobs").send({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 20, pipelineId });
       const res = await request(app).delete(`/jobs/${job.body.id}/allocations/999`);
       expect(res.status).toBe(404);
     });
+  });
+});
+
+describe("DELETE /jobs/:id", () => {
+  it("should delete a pending job and return 204", async () => {
+    const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 5, pipelineId });
+    const res = await request(app).delete(`/jobs/${job.body.id}`);
+    expect(res.status).toBe(204);
+
+    const get = await request(app).get(`/jobs/${job.body.id}`);
+    expect(get.status).toBe(404);
+  });
+
+  it("should return 409 for in-progress job without force", async () => {
+    const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 5, pipelineId });
+    db.prepare("UPDATE jobs SET status = 'in_progress' WHERE id = ?").run(job.body.id);
+
+    const res = await request(app).delete(`/jobs/${job.body.id}`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("in progress");
+  });
+
+  it("should delete in-progress job with force=true", async () => {
+    const job = await request(app).post("/jobs").send({ productType: "Widget", quantity: 5, pipelineId });
+    db.prepare("UPDATE jobs SET status = 'in_progress' WHERE id = ?").run(job.body.id);
+
+    const res = await request(app).delete(`/jobs/${job.body.id}?force=true`);
+    expect(res.status).toBe(204);
+  });
+
+  it("should return 404 for non-existent job", async () => {
+    const res = await request(app).delete("/jobs/999");
+    expect(res.status).toBe(404);
   });
 });

--- a/manu-gen/backend/src/features/jobs/jobs.controller.ts
+++ b/manu-gen/backend/src/features/jobs/jobs.controller.ts
@@ -141,6 +141,24 @@ jobsRouter.post("/:id/allocations", (req, res, next) => {
   }
 });
 
+jobsRouter.delete("/:id", (req, res, next) => {
+  try {
+    const id = parseJobId(req.params.id);
+    const force = req.query.force === "true";
+    const job = jobsService.getJobById(id);
+    if (job.status === "in_progress" && !force) {
+      throw new AppError(
+        409,
+        `Cannot delete ${job.jobNumber}: job is in progress. Use ?force=true to override.`,
+      );
+    }
+    jobsService.deleteJob(id);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
 jobsRouter.delete("/:id/allocations/:allocationId", (req, res, next) => {
   try {
     const id = parseJobId(req.params.id);

--- a/manu-gen/backend/src/features/jobs/jobs.schema.ts
+++ b/manu-gen/backend/src/features/jobs/jobs.schema.ts
@@ -8,7 +8,9 @@ export const createJobSchema = z.object({
   pipelineId: z.string().min(1, "pipelineId is required"),
 });
 
-export type CreateJobInput = z.infer<typeof createJobSchema>;
+export type CreateJobInput = z.input<typeof createJobSchema>;
+
+export type JobStatus = "pending" | "in_progress" | "completed";
 
 export interface JobRow {
   id: number;
@@ -21,6 +23,7 @@ export interface JobRow {
   created_at: string;
   pipeline_id: string;
   pipeline_name: string;
+  status: string;
 }
 
 export interface Job {
@@ -34,6 +37,7 @@ export interface Job {
   createdAt: string;
   pipelineId: string;
   pipelineName: string;
+  status: JobStatus;
 }
 
 export function toJob(row: JobRow): Job {
@@ -48,6 +52,7 @@ export function toJob(row: JobRow): Job {
     createdAt: row.created_at,
     pipelineId: row.pipeline_id,
     pipelineName: row.pipeline_name,
+    status: row.status as JobStatus,
   };
 }
 
@@ -57,6 +62,7 @@ export interface BoardJobRow {
   product_type: string;
   tray_code: string;
   created_at: string;
+  status: string;
   station_id: string | null;
   station_name: string | null;
   last_seen_at: string | null;
@@ -76,6 +82,7 @@ export interface BoardJob {
   productType: string;
   trayCode: string;
   createdAt: string;
+  status: JobStatus;
   currentStation: { id: string; name: string } | null;
   lastSeenAt: string | null;
   stationArrivedAt: string | null;
@@ -101,6 +108,7 @@ export function toBoardJob(row: BoardJobRow): BoardJob {
     productType: row.product_type,
     trayCode: row.tray_code,
     createdAt: toIso(row.created_at),
+    status: row.status as JobStatus,
     currentStation:
       row.station_id && row.station_name
         ? { id: row.station_id, name: row.station_name }

--- a/manu-gen/backend/src/features/jobs/jobs.service.test.ts
+++ b/manu-gen/backend/src/features/jobs/jobs.service.test.ts
@@ -3,6 +3,7 @@ import db from "../../db.js";
 import * as pipelinesService from "../pipelines/pipelines.service.js";
 import * as stationsService from "../stations/stations.service.js";
 import * as customerOrdersService from "../customer-orders/customer-orders.service.js";
+import * as eventsService from "../events/events.service.js";
 import * as jobsService from "./jobs.service.js";
 
 let pipelineId: string;
@@ -22,6 +23,7 @@ beforeEach(() => {
   stationId = stationsService.createStation({ name: "Test Station" }).id;
   const pipeline = pipelinesService.createPipeline({
     name: "Test Pipeline",
+    productType: "Widget",
     steps: [{ stationId, maxDurationSeconds: 120 }],
   });
   pipelineId = pipeline.id;
@@ -46,8 +48,8 @@ describe("createJob", () => {
   });
 
   it("should auto-increment job numbers", () => {
-    const j1 = jobsService.createJob({ productType: "A", quantity: 1, pipelineId });
-    const j2 = jobsService.createJob({ productType: "B", quantity: 2, pipelineId });
+    const j1 = jobsService.createJob({ productType: "Widget", quantity: 1, pipelineId });
+    const j2 = jobsService.createJob({ productType: "Widget", quantity: 2, pipelineId });
 
     expect(j1.jobNumber).toBe("JOB-0001");
     expect(j2.jobNumber).toBe("JOB-0002");
@@ -92,25 +94,25 @@ describe("getJobByTrayCode", () => {
 
 describe("listJobs", () => {
   it("should return jobs in descending order", () => {
-    jobsService.createJob({ productType: "A", quantity: 1, pipelineId });
-    jobsService.createJob({ productType: "B", quantity: 2, pipelineId });
+    jobsService.createJob({ productType: "Widget", quantity: 1, pipelineId });
+    jobsService.createJob({ productType: "Widget", quantity: 2, pipelineId });
 
     const jobs = jobsService.listJobs();
 
     expect(jobs).toHaveLength(2);
-    expect(jobs[0].productType).toBe("B");
-    expect(jobs[1].productType).toBe("A");
+    expect(jobs[0].jobNumber).toBe("JOB-0002");
+    expect(jobs[1].jobNumber).toBe("JOB-0001");
   });
 
   it("should respect limit and offset", () => {
-    jobsService.createJob({ productType: "A", quantity: 1, pipelineId });
-    jobsService.createJob({ productType: "B", quantity: 2, pipelineId });
-    jobsService.createJob({ productType: "C", quantity: 3, pipelineId });
+    jobsService.createJob({ productType: "Widget", quantity: 1, pipelineId });
+    jobsService.createJob({ productType: "Widget", quantity: 2, pipelineId });
+    jobsService.createJob({ productType: "Widget", quantity: 3, pipelineId });
 
     const page = jobsService.listJobs({ limit: 1, offset: 1 });
 
     expect(page).toHaveLength(1);
-    expect(page[0].productType).toBe("B");
+    expect(page[0].jobNumber).toBe("JOB-0002");
   });
 });
 
@@ -171,7 +173,7 @@ describe("allocations", () => {
   function createOrderWithLine() {
     const order = customerOrdersService.createCustomerOrder({
       customerName: "Acme",
-      lines: [{ productType: "Sprocket", quantity: 10 }],
+      lines: [{ productType: "Widget", quantity: 10 }],
     });
     return { orderId: order.id, lineId: order.lines[0].id };
   }
@@ -179,7 +181,7 @@ describe("allocations", () => {
   describe("addAllocation", () => {
     it("should allocate a quantity from a job to an order line", () => {
       const { lineId } = createOrderWithLine();
-      const job = jobsService.createJob({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
 
       const alloc = jobsService.addAllocation(job.id, { orderLineId: lineId, quantity: 5 });
 
@@ -192,7 +194,7 @@ describe("allocations", () => {
 
     it("should reject duplicate allocation for same job + order line", () => {
       const { lineId } = createOrderWithLine();
-      const job = jobsService.createJob({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
 
       jobsService.addAllocation(job.id, { orderLineId: lineId, quantity: 5 });
 
@@ -210,7 +212,7 @@ describe("allocations", () => {
     });
 
     it("should throw 404 for non-existent order line", () => {
-      const job = jobsService.createJob({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
 
       expect(() =>
         jobsService.addAllocation(job.id, { orderLineId: 999, quantity: 1 }),
@@ -219,7 +221,7 @@ describe("allocations", () => {
 
     it("should throw 422 when allocation exceeds job capacity", () => {
       const { lineId } = createOrderWithLine();
-      const job = jobsService.createJob({ productType: "Sprocket", quantity: 5, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 5, pipelineId });
 
       expect(() =>
         jobsService.addAllocation(job.id, { orderLineId: lineId, quantity: 10 }),
@@ -229,14 +231,14 @@ describe("allocations", () => {
     it("should throw 422 when remaining capacity is insufficient", () => {
       const order1 = customerOrdersService.createCustomerOrder({
         customerName: "First",
-        lines: [{ productType: "Bolt", quantity: 8 }],
+        lines: [{ productType: "Widget", quantity: 8 }],
       });
-      const job = jobsService.createJob({ productType: "Bolt", quantity: 10, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 10, pipelineId });
       jobsService.addAllocation(job.id, { orderLineId: order1.lines[0].id, quantity: 8 });
 
       const order2 = customerOrdersService.createCustomerOrder({
         customerName: "Second",
-        lines: [{ productType: "Bolt", quantity: 5 }],
+        lines: [{ productType: "Widget", quantity: 5 }],
       });
 
       expect(() =>
@@ -260,7 +262,7 @@ describe("allocations", () => {
   describe("listAllocations", () => {
     it("should return allocations for a job", () => {
       const { lineId } = createOrderWithLine();
-      const job = jobsService.createJob({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
       jobsService.addAllocation(job.id, { orderLineId: lineId, quantity: 5 });
 
       const allocs = jobsService.listAllocations(job.id);
@@ -270,7 +272,7 @@ describe("allocations", () => {
     });
 
     it("should return empty array when no allocations", () => {
-      const job = jobsService.createJob({ productType: "Sprocket", quantity: 5, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 5, pipelineId });
       expect(jobsService.listAllocations(job.id)).toEqual([]);
     });
   });
@@ -278,7 +280,7 @@ describe("allocations", () => {
   describe("removeAllocation", () => {
     it("should remove an allocation", () => {
       const { lineId } = createOrderWithLine();
-      const job = jobsService.createJob({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
       const alloc = jobsService.addAllocation(job.id, { orderLineId: lineId, quantity: 5 });
 
       jobsService.removeAllocation(job.id, alloc.id);
@@ -287,11 +289,168 @@ describe("allocations", () => {
     });
 
     it("should throw 404 for non-existent allocation", () => {
-      const job = jobsService.createJob({ productType: "Sprocket", quantity: 20, pipelineId });
+      const job = jobsService.createJob({ productType: "Widget", quantity: 20, pipelineId });
 
       expect(() => jobsService.removeAllocation(job.id, 999)).toThrow(
         expect.objectContaining({ statusCode: 404 }),
       );
     });
+  });
+});
+
+describe("onTrackingEvent (status transitions)", () => {
+  it("should transition pending job to in_progress on first event", () => {
+    const job = jobsService.createJob({ productType: "Widget", quantity: 10, pipelineId });
+    expect(jobsService.getJobById(job.id).status).toBe("pending");
+
+    eventsService.createEvent({
+      trayCode: job.trayCode,
+      stationId,
+      eyeId: "eye-1",
+      capturedAt: new Date().toISOString(),
+      phase: "arrived",
+    });
+
+    expect(jobsService.getJobById(job.id).status).toBe("in_progress");
+  });
+
+  it("should transition in_progress to completed when all steps departed", () => {
+    const job = jobsService.createJob({ productType: "Widget", quantity: 10, pipelineId });
+
+    eventsService.createEvent({
+      trayCode: job.trayCode,
+      stationId,
+      eyeId: "eye-1",
+      capturedAt: new Date().toISOString(),
+      phase: "arrived",
+    });
+    expect(jobsService.getJobById(job.id).status).toBe("in_progress");
+
+    eventsService.createEvent({
+      trayCode: job.trayCode,
+      stationId,
+      eyeId: "eye-1",
+      capturedAt: new Date().toISOString(),
+      phase: "departed",
+    });
+    expect(jobsService.getJobById(job.id).status).toBe("completed");
+  });
+
+  it("should not change status for unknown tray codes", () => {
+    jobsService.createJob({ productType: "Widget", quantity: 10, pipelineId });
+
+    eventsService.createEvent({
+      trayCode: "UNKNOWN-TRAY",
+      stationId,
+      eyeId: "eye-1",
+      capturedAt: new Date().toISOString(),
+      phase: "arrived",
+    });
+
+    const job = jobsService.getJobById(1);
+    expect(job.status).toBe("pending");
+  });
+
+  it("should not change completed status on further events", () => {
+    const job = jobsService.createJob({ productType: "Widget", quantity: 10, pipelineId });
+
+    eventsService.createEvent({
+      trayCode: job.trayCode,
+      stationId,
+      eyeId: "eye-1",
+      capturedAt: new Date().toISOString(),
+      phase: "arrived",
+    });
+    eventsService.createEvent({
+      trayCode: job.trayCode,
+      stationId,
+      eyeId: "eye-1",
+      capturedAt: new Date().toISOString(),
+      phase: "departed",
+    });
+    expect(jobsService.getJobById(job.id).status).toBe("completed");
+
+    eventsService.createEvent({
+      trayCode: job.trayCode,
+      stationId,
+      eyeId: "eye-1",
+      capturedAt: new Date().toISOString(),
+      phase: "arrived",
+    });
+    expect(jobsService.getJobById(job.id).status).toBe("completed");
+  });
+});
+
+describe("deleteJob", () => {
+  it("should delete a job with no allocations or events", () => {
+    const job = jobsService.createJob({ productType: "Widget", quantity: 5, pipelineId });
+    jobsService.deleteJob(job.id);
+
+    expect(() => jobsService.getJobById(job.id)).toThrow(
+      expect.objectContaining({ statusCode: 404 }),
+    );
+  });
+
+  it("should cascade-delete allocations and tracking events", () => {
+    const job = jobsService.createJob({ productType: "Widget", quantity: 10, pipelineId });
+
+    const order = customerOrdersService.createCustomerOrder({
+      customerName: "Test",
+      lines: [{ productType: "Widget", quantity: 5 }],
+    });
+    jobsService.addAllocation(job.id, { orderLineId: order.lines[0].id, quantity: 3 });
+
+    eventsService.createEvent({
+      trayCode: job.trayCode,
+      stationId,
+      eyeId: "eye-1",
+      capturedAt: new Date().toISOString(),
+      phase: "arrived",
+    });
+
+    jobsService.deleteJob(job.id);
+
+    expect(() => jobsService.getJobById(job.id)).toThrow(
+      expect.objectContaining({ statusCode: 404 }),
+    );
+    const { cnt } = db.prepare("SELECT COUNT(*) AS cnt FROM tracking_events WHERE tray_code = ?").get(job.trayCode) as { cnt: number };
+    expect(cnt).toBe(0);
+  });
+
+  it("should throw 404 for non-existent job", () => {
+    expect(() => jobsService.deleteJob(999)).toThrow(
+      expect.objectContaining({ statusCode: 404 }),
+    );
+  });
+});
+
+describe("createJob validations", () => {
+  it("should throw 422 when quantity exceeds pipeline capacity", () => {
+    const capacityPipeline = pipelinesService.createPipeline({
+      name: "Capped",
+      productType: "Capped",
+      steps: [{ stationId, maxDurationSeconds: 60, maxCapacity: 10 }],
+    });
+
+    expect(() =>
+      jobsService.createJob({ productType: "Capped", quantity: 15, pipelineId: capacityPipeline.id }),
+    ).toThrow(expect.objectContaining({ statusCode: 422 }));
+  });
+
+  it("should allow quantity at exactly pipeline capacity", () => {
+    const capacityPipeline = pipelinesService.createPipeline({
+      name: "Exact",
+      productType: "Exact",
+      steps: [{ stationId, maxDurationSeconds: 60, maxCapacity: 10 }],
+    });
+
+    const job = jobsService.createJob({ productType: "Exact", quantity: 10, pipelineId: capacityPipeline.id });
+    expect(job.quantity).toBe(10);
+  });
+
+  it("should throw 422 when product type does not match pipeline", () => {
+    expect(() =>
+      jobsService.createJob({ productType: "Wrong", quantity: 1, pipelineId }),
+    ).toThrow(expect.objectContaining({ statusCode: 422 }));
   });
 });

--- a/manu-gen/backend/src/features/jobs/jobs.service.ts
+++ b/manu-gen/backend/src/features/jobs/jobs.service.ts
@@ -2,6 +2,7 @@ import QRCode from "qrcode";
 import db from "../../db.js";
 import { AppError } from "../../shared/errors/app-error.js";
 import { parseUtcMs, toIso } from "../../shared/datetime.js";
+import { getPipelineById } from "../pipelines/pipelines.service.js";
 import type {
   CreateJobInput,
   CreateAllocationInput,
@@ -23,7 +24,7 @@ const QR_OPTIONS = {
   errorCorrectionLevel: "H",
 } as const;
 
-const JOB_COLUMNS = `o.id, o.job_number, o.product_type, o.quantity, o.notes, o.tray_code, o.created_at, o.pipeline_id, p.name AS pipeline_name,
+const JOB_COLUMNS = `o.id, o.job_number, o.product_type, o.quantity, o.notes, o.tray_code, o.created_at, o.pipeline_id, o.status, p.name AS pipeline_name,
   COALESCE((SELECT SUM(ja.quantity) FROM job_allocations ja WHERE ja.job_id = o.id), 0) AS allocated_quantity`;
 
 function formatJobNumber(id: number): string {
@@ -70,6 +71,19 @@ const createJobTx = db.transaction((input: CreateJobInput): number => {
 });
 
 export function createJob(input: CreateJobInput): Job {
+  const pipeline = getPipelineById(input.pipelineId);
+  if (pipeline.productType && pipeline.productType !== input.productType) {
+    throw new AppError(
+      422,
+      `Product type "${input.productType}" does not match pipeline product type "${pipeline.productType}"`,
+    );
+  }
+  if (pipeline.effectiveCapacity !== null && input.quantity > pipeline.effectiveCapacity) {
+    throw new AppError(
+      422,
+      `Quantity ${input.quantity} exceeds pipeline capacity of ${pipeline.effectiveCapacity}`,
+    );
+  }
   const id = createJobTx(input);
   return getJobById(id);
 }
@@ -95,6 +109,25 @@ export function listJobs({ limit = 50, offset = 0 }: { limit?: number; offset?: 
   return rows.map(toJob);
 }
 
+const stmtDeleteAllocsByJob = db.prepare("DELETE FROM job_allocations WHERE job_id = ?");
+const stmtTrayCodeById = db.prepare("SELECT tray_code FROM jobs WHERE id = ?");
+const stmtDeleteEventsByTray = db.prepare("DELETE FROM tracking_events WHERE tray_code = ?");
+const stmtDeleteJob = db.prepare("DELETE FROM jobs WHERE id = ?");
+
+const deleteJobTx = db.transaction((id: number) => {
+  const row = stmtTrayCodeById.get(id) as { tray_code: string } | undefined;
+  if (!row) {
+    throw new AppError(404, `Job with id ${id} not found`);
+  }
+  stmtDeleteAllocsByJob.run(id);
+  stmtDeleteEventsByTray.run(row.tray_code);
+  stmtDeleteJob.run(id);
+});
+
+export function deleteJob(id: number): void {
+  deleteJobTx(id);
+}
+
 const stmtJobBoard = db.prepare(`
   SELECT
     o.id,
@@ -102,6 +135,7 @@ const stmtJobBoard = db.prepare(`
     o.product_type,
     o.tray_code,
     o.created_at,
+    o.status,
     CASE WHEN ranked.phase = 'departed' THEN NULL ELSE ranked.station_id END AS station_id,
     CASE WHEN ranked.phase = 'departed' THEN NULL ELSE s.name END AS station_name,
     ranked.captured_at AS last_seen_at,
@@ -335,4 +369,58 @@ export function removeAllocation(jobId: number, allocationId: number): void {
     throw new AppError(404, `Allocation ${allocationId} not found on job ${jobId}`);
   }
   stmtDeleteAllocation.run(allocationId, jobId);
+}
+
+const stmtUpdateQuantity = db.prepare(`UPDATE jobs SET quantity = quantity + @delta WHERE id = @id`);
+
+const stmtUpdateStatus = db.prepare(`UPDATE jobs SET status = @status WHERE id = @id`);
+
+const stmtJobByTrayCode = db.prepare(`SELECT id, status, pipeline_id FROM jobs WHERE tray_code = ?`);
+
+const stmtDepartedStationCount = db.prepare(`
+  SELECT COUNT(DISTINCT te.station_id) AS cnt
+  FROM tracking_events te
+  WHERE te.tray_code = ? AND te.phase = 'departed'
+`);
+
+const stmtPipelineStepCount = db.prepare(`
+  SELECT COUNT(*) AS cnt FROM pipeline_steps WHERE pipeline_id = ?
+`);
+
+export function packIntoJob(jobId: number, additionalQuantity: number): void {
+  stmtUpdateQuantity.run({ id: jobId, delta: additionalQuantity });
+}
+
+export function createJobRaw(productType: string, quantity: number, pipelineId: string): number {
+  const { next_id: nextId } = stmtNextId.get() as { next_id: number };
+  stmtInsert.run({
+    id: nextId,
+    job_number: formatJobNumber(nextId),
+    product_type: productType,
+    quantity,
+    notes: "",
+    tray_code: formatTrayCode(nextId),
+    pipeline_id: pipelineId,
+  });
+  return nextId;
+}
+
+export function onTrackingEvent(trayCode: string): void {
+  const job = stmtJobByTrayCode.get(trayCode) as
+    | { id: number; status: string; pipeline_id: string }
+    | undefined;
+  if (!job) return;
+
+  if (job.status === "pending") {
+    stmtUpdateStatus.run({ id: job.id, status: "in_progress" });
+    return;
+  }
+
+  if (job.status === "in_progress") {
+    const { cnt: departed } = stmtDepartedStationCount.get(trayCode) as { cnt: number };
+    const { cnt: totalSteps } = stmtPipelineStepCount.get(job.pipeline_id) as { cnt: number };
+    if (totalSteps > 0 && departed >= totalSteps) {
+      stmtUpdateStatus.run({ id: job.id, status: "completed" });
+    }
+  }
 }

--- a/manu-gen/backend/src/features/pipelines/pipelines.controller.test.ts
+++ b/manu-gen/backend/src/features/pipelines/pipelines.controller.test.ts
@@ -23,6 +23,7 @@ describe("POST /pipelines", () => {
   it("should create a pipeline and return 201", async () => {
     const res = await request(app).post("/pipelines").send({
       name: "Flow A",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: 120 }],
     });
 
@@ -34,6 +35,7 @@ describe("POST /pipelines", () => {
 
   it("should return 400 when name is missing", async () => {
     const res = await request(app).post("/pipelines").send({
+      productType: "Widget",
       steps: [{ stationId }],
     });
 
@@ -44,6 +46,7 @@ describe("POST /pipelines", () => {
   it("should return 400 when steps is empty", async () => {
     const res = await request(app).post("/pipelines").send({
       name: "Empty",
+      productType: "Widget",
       steps: [],
     });
 
@@ -64,6 +67,7 @@ describe("GET /pipelines/:id", () => {
   it("should return the pipeline when it exists", async () => {
     const createRes = await request(app).post("/pipelines").send({
       name: "Flow",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: null }],
     });
     const id = createRes.body.id;
@@ -85,6 +89,7 @@ describe("DELETE /pipelines/:id", () => {
   it("should delete a pipeline with no jobs and return 204", async () => {
     const createRes = await request(app).post("/pipelines").send({
       name: "Temp",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: null }],
     });
     const id = createRes.body.id;
@@ -97,6 +102,7 @@ describe("DELETE /pipelines/:id", () => {
   it("should return 409 when pipeline has jobs", async () => {
     const createRes = await request(app).post("/pipelines").send({
       name: "Busy",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: null }],
     });
     const pipelineId = createRes.body.id;
@@ -121,14 +127,14 @@ describe("DELETE /pipelines/:id", () => {
 });
 
 describe("POST /jobs with nonexistent pipelineId", () => {
-  it("should return 400 for FK violation", async () => {
+  it("should return 404 for unknown pipeline", async () => {
     const res = await request(app).post("/jobs").send({
       productType: "Widget",
       quantity: 1,
       pipelineId: "pipeline-does-not-exist",
     });
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain("does not exist");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain("not found");
   });
 });

--- a/manu-gen/backend/src/features/pipelines/pipelines.schema.ts
+++ b/manu-gen/backend/src/features/pipelines/pipelines.schema.ts
@@ -1,36 +1,30 @@
 import { z } from "zod";
 
+const stepSchema = z.object({
+  stationId: z.string().min(1, "stationId is required"),
+  maxDurationSeconds: z.number().int().min(1).nullable().optional().default(null),
+  maxCapacity: z.number().int().min(1).nullable().optional().default(null),
+});
+
 export const createPipelineSchema = z.object({
   name: z.string().min(1, "name is required"),
   description: z.string().optional().default(""),
-  steps: z
-    .array(
-      z.object({
-        stationId: z.string().min(1, "stationId is required"),
-        maxDurationSeconds: z.number().int().min(1).nullable().optional().default(null),
-      }),
-    )
-    .min(1, "at least one step is required"),
+  productType: z.string().min(1, "productType is required"),
+  steps: z.array(stepSchema).min(1, "at least one step is required"),
 });
 
-export type CreatePipelineInput = z.infer<typeof createPipelineSchema>;
+export type CreatePipelineInput = z.input<typeof createPipelineSchema>;
 
 export const updatePipelineSchema = z.object({
   name: z.string().min(1, "name is required").optional(),
   description: z.string().optional(),
+  productType: z.string().min(1).optional(),
 });
 
 export type UpdatePipelineInput = z.input<typeof updatePipelineSchema>;
 
 export const replacePipelineStepsSchema = z.object({
-  steps: z
-    .array(
-      z.object({
-        stationId: z.string().min(1, "stationId is required"),
-        maxDurationSeconds: z.number().int().min(1).nullable().optional().default(null),
-      }),
-    )
-    .min(1, "at least one step is required"),
+  steps: z.array(stepSchema).min(1, "at least one step is required"),
 });
 
 export type ReplacePipelineStepsInput = z.infer<typeof replacePipelineStepsSchema>;
@@ -39,6 +33,7 @@ export interface PipelineRow {
   id: string;
   name: string;
   description: string;
+  product_type: string;
   created_at: string;
 }
 
@@ -48,6 +43,7 @@ export interface PipelineStepRow {
   station_id: string;
   position: number;
   max_duration_seconds: number | null;
+  max_capacity: number | null;
 }
 
 export interface PipelineStep {
@@ -56,15 +52,18 @@ export interface PipelineStep {
   stationName: string;
   position: number;
   maxDurationSeconds: number | null;
+  maxCapacity: number | null;
 }
 
 export interface Pipeline {
   id: string;
   name: string;
   description: string;
+  productType: string;
   createdAt: string;
   steps: PipelineStep[];
   totalExpectedSeconds: number | null;
+  effectiveCapacity: number | null;
 }
 
 export interface PipelineStepJoinRow extends PipelineStepRow {
@@ -78,7 +77,13 @@ export function toPipelineStep(row: PipelineStepJoinRow): PipelineStep {
     stationName: row.station_name,
     position: row.position,
     maxDurationSeconds: row.max_duration_seconds,
+    maxCapacity: row.max_capacity,
   };
+}
+
+export function computeEffectiveCapacity(steps: PipelineStep[]): number | null {
+  const caps = steps.map((s) => s.maxCapacity).filter((c): c is number => c !== null);
+  return caps.length > 0 ? Math.min(...caps) : null;
 }
 
 export function toPipeline(row: PipelineRow, stepRows: PipelineStepJoinRow[]): Pipeline {
@@ -92,8 +97,10 @@ export function toPipeline(row: PipelineRow, stepRows: PipelineStepJoinRow[]): P
     id: row.id,
     name: row.name,
     description: row.description,
+    productType: row.product_type,
     createdAt: row.created_at,
     steps,
     totalExpectedSeconds,
+    effectiveCapacity: computeEffectiveCapacity(steps),
   };
 }

--- a/manu-gen/backend/src/features/pipelines/pipelines.service.test.ts
+++ b/manu-gen/backend/src/features/pipelines/pipelines.service.test.ts
@@ -24,6 +24,7 @@ describe("createPipeline", () => {
   it("should create a pipeline with steps", () => {
     const pipeline = pipelinesService.createPipeline({
       name: "Flow A",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: 120 }],
     });
 
@@ -37,6 +38,7 @@ describe("createPipeline", () => {
   it("should default description to empty string", () => {
     const pipeline = pipelinesService.createPipeline({
       name: "Flow B",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: null }],
     });
 
@@ -47,6 +49,7 @@ describe("createPipeline", () => {
     const s2 = stationsService.createStation({ name: "Station 2" });
     const pipeline = pipelinesService.createPipeline({
       name: "Timed",
+      productType: "Widget",
       steps: [
         { stationId, maxDurationSeconds: 60 },
         { stationId: s2.id, maxDurationSeconds: 90 },
@@ -60,6 +63,7 @@ describe("createPipeline", () => {
     const s2 = stationsService.createStation({ name: "Station 2" });
     const pipeline = pipelinesService.createPipeline({
       name: "Partial",
+      productType: "Widget",
       steps: [
         { stationId, maxDurationSeconds: 60 },
         { stationId: s2.id, maxDurationSeconds: null },
@@ -74,6 +78,7 @@ describe("getPipelineById", () => {
   it("should return the pipeline when it exists", () => {
     const created = pipelinesService.createPipeline({
       name: "Flow",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: null }],
     });
     const found = pipelinesService.getPipelineById(created.id);
@@ -91,8 +96,8 @@ describe("getPipelineById", () => {
 
 describe("listPipelines", () => {
   it("should return pipelines ordered by name", () => {
-    pipelinesService.createPipeline({ name: "Zeta", steps: [{ stationId, maxDurationSeconds: null }] });
-    pipelinesService.createPipeline({ name: "Alpha", steps: [{ stationId, maxDurationSeconds: null }] });
+    pipelinesService.createPipeline({ name: "Zeta", productType: "TypeA", steps: [{ stationId, maxDurationSeconds: null }] });
+    pipelinesService.createPipeline({ name: "Alpha", productType: "TypeB", steps: [{ stationId, maxDurationSeconds: null }] });
 
     const list = pipelinesService.listPipelines();
 
@@ -102,9 +107,9 @@ describe("listPipelines", () => {
   });
 
   it("should respect limit and offset", () => {
-    pipelinesService.createPipeline({ name: "A", steps: [{ stationId, maxDurationSeconds: null }] });
-    pipelinesService.createPipeline({ name: "B", steps: [{ stationId, maxDurationSeconds: null }] });
-    pipelinesService.createPipeline({ name: "C", steps: [{ stationId, maxDurationSeconds: null }] });
+    pipelinesService.createPipeline({ name: "A", productType: "TypeX", steps: [{ stationId, maxDurationSeconds: null }] });
+    pipelinesService.createPipeline({ name: "B", productType: "TypeY", steps: [{ stationId, maxDurationSeconds: null }] });
+    pipelinesService.createPipeline({ name: "C", productType: "TypeZ", steps: [{ stationId, maxDurationSeconds: null }] });
 
     const page = pipelinesService.listPipelines({ limit: 1, offset: 1 });
 
@@ -117,6 +122,7 @@ describe("deletePipeline", () => {
   it("should delete a pipeline with no jobs", () => {
     const pipeline = pipelinesService.createPipeline({
       name: "Disposable",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: null }],
     });
 
@@ -130,6 +136,7 @@ describe("deletePipeline", () => {
   it("should reject deletion when jobs reference the pipeline", () => {
     const pipeline = pipelinesService.createPipeline({
       name: "In Use",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: null }],
     });
 
@@ -159,6 +166,7 @@ describe("replaceSteps", () => {
     const s2 = stationsService.createStation({ name: "Station 2" });
     const pipeline = pipelinesService.createPipeline({
       name: "Flow",
+      productType: "Widget",
       steps: [{ stationId, maxDurationSeconds: 60 }],
     });
 

--- a/manu-gen/backend/src/features/pipelines/pipelines.service.ts
+++ b/manu-gen/backend/src/features/pipelines/pipelines.service.ts
@@ -12,25 +12,29 @@ import type {
 import { toPipeline } from "./pipelines.schema.js";
 
 const stmtInsert = db.prepare(
-  `INSERT INTO pipelines (id, name, description) VALUES (@id, @name, @description)`,
+  `INSERT INTO pipelines (id, name, description, product_type) VALUES (@id, @name, @description, @product_type)`,
 );
 
 const stmtGetById = db.prepare(
-  `SELECT id, name, description, created_at FROM pipelines WHERE id = ?`,
+  `SELECT id, name, description, product_type, created_at FROM pipelines WHERE id = ?`,
 );
 
 const stmtList = db.prepare(
-  `SELECT id, name, description, created_at FROM pipelines ORDER BY name LIMIT ? OFFSET ?`,
+  `SELECT id, name, description, product_type, created_at FROM pipelines ORDER BY name LIMIT ? OFFSET ?`,
+);
+
+const stmtGetByProductType = db.prepare(
+  `SELECT id, name, description, product_type, created_at FROM pipelines WHERE product_type = ?`,
 );
 
 const stmtUpdate = db.prepare(
-  `UPDATE pipelines SET name = COALESCE(@name, name), description = COALESCE(@description, description) WHERE id = @id`,
+  `UPDATE pipelines SET name = COALESCE(@name, name), description = COALESCE(@description, description), product_type = COALESCE(@product_type, product_type) WHERE id = @id`,
 );
 
 const stmtDelete = db.prepare(`DELETE FROM pipelines WHERE id = ?`);
 
 const stmtStepsByPipeline = db.prepare(
-  `SELECT ps.id, ps.pipeline_id, ps.station_id, ps.position, ps.max_duration_seconds, s.name AS station_name
+  `SELECT ps.id, ps.pipeline_id, ps.station_id, ps.position, ps.max_duration_seconds, ps.max_capacity, s.name AS station_name
    FROM pipeline_steps ps
    JOIN stations s ON s.id = ps.station_id
    WHERE ps.pipeline_id = ?
@@ -38,8 +42,8 @@ const stmtStepsByPipeline = db.prepare(
 );
 
 const stmtInsertStep = db.prepare(
-  `INSERT INTO pipeline_steps (pipeline_id, station_id, position, max_duration_seconds)
-   VALUES (@pipeline_id, @station_id, @position, @max_duration_seconds)`,
+  `INSERT INTO pipeline_steps (pipeline_id, station_id, position, max_duration_seconds, max_capacity)
+   VALUES (@pipeline_id, @station_id, @position, @max_duration_seconds, @max_capacity)`,
 );
 
 const stmtDeleteStepsByPipeline = db.prepare(
@@ -69,13 +73,19 @@ function insertSteps(
       station_id: step.stationId,
       position: i + 1,
       max_duration_seconds: step.maxDurationSeconds,
+      max_capacity: step.maxCapacity,
     });
   }
 }
 
 const createPipelineTx = db.transaction((input: CreatePipelineInput): string => {
   const id = generateId();
-  stmtInsert.run({ id, name: input.name, description: input.description ?? "" });
+  stmtInsert.run({
+    id,
+    name: input.name,
+    description: input.description ?? "",
+    product_type: input.productType,
+  });
   insertSteps(id, input.steps);
   return id;
 });
@@ -106,7 +116,12 @@ export function updatePipeline(id: string, input: UpdatePipelineInput): Pipeline
   if (!row) {
     throw new AppError(404, `Pipeline with id ${id} not found`);
   }
-  stmtUpdate.run({ id, name: input.name ?? null, description: input.description ?? null });
+  stmtUpdate.run({
+    id,
+    name: input.name ?? null,
+    description: input.description ?? null,
+    product_type: input.productType ?? null,
+  });
   return getPipelineById(id);
 }
 
@@ -152,4 +167,10 @@ export function deletePipeline(id: string): void {
 export function countJobsUsingPipeline(id: string): number {
   const row = stmtJobsUsingPipeline.get(id) as { cnt: number };
   return row.cnt;
+}
+
+export function getPipelineByProductType(productType: string): Pipeline | null {
+  const row = stmtGetByProductType.get(productType) as PipelineRow | undefined;
+  if (!row) return null;
+  return toPipeline(row, getStepRows(row.id));
 }

--- a/manu-gen/backend/src/features/stations/stations.controller.test.ts
+++ b/manu-gen/backend/src/features/stations/stations.controller.test.ts
@@ -197,6 +197,7 @@ describe("DELETE /stations/:id", () => {
 
     pipelinesService.createPipeline({
       name: "Flow",
+      productType: "Widget",
       steps: [{ stationId: id, maxDurationSeconds: null }],
     });
 

--- a/manu-gen/backend/src/features/stations/stations.schema.ts
+++ b/manu-gen/backend/src/features/stations/stations.schema.ts
@@ -5,7 +5,7 @@ export const createStationSchema = z.object({
   location: z.string().optional().default(""),
 });
 
-export type CreateStationInput = z.infer<typeof createStationSchema>;
+export type CreateStationInput = z.input<typeof createStationSchema>;
 
 export const assignEyeSchema = z.object({
   eyeId: z.string().min(1, "eyeId is required"),

--- a/manu-gen/backend/src/features/stations/stations.service.test.ts
+++ b/manu-gen/backend/src/features/stations/stations.service.test.ts
@@ -158,6 +158,7 @@ describe("deleteStation", () => {
     const station = stationsService.createStation({ name: "In Pipeline" });
     pipelinesService.createPipeline({
       name: "Flow",
+      productType: "Widget",
       steps: [{ stationId: station.id, maxDurationSeconds: null }],
     });
 

--- a/manu-gen/frontend/src/features/customer-orders/components/CustomerOrderDetail.tsx
+++ b/manu-gen/frontend/src/features/customer-orders/components/CustomerOrderDetail.tsx
@@ -287,6 +287,44 @@ export function CustomerOrderDetail({
         </div>
       </div>
 
+      <div className="rounded-lg border bg-white p-6 shadow-sm">
+        <h4 className="mb-3 text-sm font-semibold uppercase text-gray-500">
+          Order Summary
+        </h4>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-gray-500">
+              <th className="py-2 pr-4 font-medium">Product Type</th>
+              <th className="py-2 pr-4 font-medium text-right">Requested</th>
+              <th className="py-2 pr-4 font-medium text-right">Allocated</th>
+              <th className="py-2 pr-4 font-medium text-right">Fulfilled</th>
+              <th className="py-2 font-medium text-right">Progress</th>
+            </tr>
+          </thead>
+          <tbody>
+            {order.lines.map((line) => {
+              const pct = line.quantity > 0 ? Math.round((Math.min(line.fulfilledQuantity, line.quantity) / line.quantity) * 100) : 0;
+              return (
+                <tr key={line.id} className="border-b last:border-0">
+                  <td className="py-2 pr-4 font-medium text-gray-900">{line.productType}</td>
+                  <td className="py-2 pr-4 text-right">{line.quantity}</td>
+                  <td className="py-2 pr-4 text-right">{line.allocatedQuantity}</td>
+                  <td className="py-2 pr-4 text-right">{line.fulfilledQuantity}</td>
+                  <td className="py-2 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <div className="h-2 w-16 overflow-hidden rounded-full bg-gray-200">
+                        <div className="h-2 rounded-full bg-green-500 transition-all" style={{ width: `${pct}%` }} />
+                      </div>
+                      <span className="w-10 text-xs text-gray-500">{pct}%</span>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
       <div>
         <h4 className="mb-3 text-sm font-semibold uppercase text-gray-500">
           Line Items &amp; Job Allocations

--- a/manu-gen/frontend/src/features/customer-orders/components/CustomerOrderList.tsx
+++ b/manu-gen/frontend/src/features/customer-orders/components/CustomerOrderList.tsx
@@ -1,4 +1,5 @@
 import { useCustomerOrders } from "../hooks/useCustomerOrders";
+import { useDeleteCustomerOrder } from "../hooks/useDeleteCustomerOrder";
 import type { CustomerOrderSummary } from "../customer-orders.types";
 
 const STATUS_LABELS: Record<string, string> = {
@@ -22,6 +23,7 @@ interface CustomerOrderListProps {
 
 export function CustomerOrderList({ selectedId, onSelect }: CustomerOrderListProps) {
   const { data: orders, isLoading, error } = useCustomerOrders();
+  const deleteMutation = useDeleteCustomerOrder();
 
   if (isLoading) return <p className="text-sm text-gray-500">Loading...</p>;
   if (error) return <p className="text-sm text-red-600">Error: {error.message}</p>;
@@ -39,6 +41,7 @@ export function CustomerOrderList({ selectedId, onSelect }: CustomerOrderListPro
             <th className="px-3 py-2">Allocated</th>
             <th className="px-3 py-2">Fulfilled</th>
             <th className="px-3 py-2">Due</th>
+            <th className="px-3 py-2"></th>
           </tr>
         </thead>
         <tbody>
@@ -50,7 +53,10 @@ export function CustomerOrderList({ selectedId, onSelect }: CustomerOrderListPro
               aria-selected={selectedId === order.id}
               onClick={() => onSelect(order)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") onSelect(order);
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSelect(order);
+                }
               }}
               className={`cursor-pointer border-b transition-colors hover:bg-gray-50 ${
                 selectedId === order.id ? "bg-blue-50" : ""
@@ -92,6 +98,20 @@ export function CustomerOrderList({ selectedId, onSelect }: CustomerOrderListPro
               </td>
               <td className="px-3 py-2 text-xs text-gray-500">
                 {order.dueDate ?? "---"}
+              </td>
+              <td className="px-3 py-2">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (confirm(`Delete ${order.orderNumber}? Allocations will also be removed.`)) {
+                      deleteMutation.mutate(order.id);
+                    }
+                  }}
+                  className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                >
+                  Delete
+                </button>
               </td>
             </tr>
           ))}

--- a/manu-gen/frontend/src/features/customer-orders/hooks/useCreateCustomerOrder.ts
+++ b/manu-gen/frontend/src/features/customer-orders/hooks/useCreateCustomerOrder.ts
@@ -16,7 +16,8 @@ export function useCreateCustomerOrder() {
       return apiClient.post<CustomerOrder>("/customer-orders", body);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["customer-orders"] });
+      void queryClient.invalidateQueries({ queryKey: ["customer-orders"] });
+      void queryClient.invalidateQueries({ queryKey: ["jobs"] });
     },
   });
 }

--- a/manu-gen/frontend/src/features/customer-orders/hooks/useDeleteCustomerOrder.ts
+++ b/manu-gen/frontend/src/features/customer-orders/hooks/useDeleteCustomerOrder.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+
+export function useDeleteCustomerOrder() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiClient.delete(`/customer-orders/${id}`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["customer-orders"] });
+      void queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    },
+  });
+}

--- a/manu-gen/frontend/src/features/dashboard/components/DashboardPage.tsx
+++ b/manu-gen/frontend/src/features/dashboard/components/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { useJobBoard } from "../hooks/useJobBoard";
 import { OverviewVisibleContext } from "../OverviewVisibleContext";
 import { CustomerOrderList } from "../../customer-orders/components/CustomerOrderList";
 import { CustomerOrderDetail } from "../../customer-orders/components/CustomerOrderDetail";
+import { useOrderMetrics } from "../hooks/useOrderMetrics";
 
 type DashboardTab = "customer-orders" | "operations";
 
@@ -13,6 +14,7 @@ export function DashboardPage() {
   const [selectedJobId, setSelectedJobId] = useState<number | null>(null);
   const [selectedCustomerOrderId, setSelectedCustomerOrderId] = useState<number | null>(null);
   const { data: jobs } = useJobBoard();
+  const { data: orderMetrics } = useOrderMetrics();
   const selectedJob = jobs?.find((j) => j.id === selectedJobId) ?? null;
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -57,12 +59,63 @@ export function DashboardPage() {
             readonly
           />
         ) : (
-          <div className="rounded-lg border bg-white p-6 shadow-sm">
-            <h3 className="mb-4 text-lg font-semibold">Customer Orders</h3>
-            <CustomerOrderList
-              selectedId={selectedCustomerOrderId}
-              onSelect={(order) => setSelectedCustomerOrderId(order.id)}
-            />
+          <div className="space-y-6">
+            {orderMetrics && (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                <div className="rounded-lg border bg-white p-4 shadow-sm">
+                  <p className="text-xs font-medium uppercase text-gray-500">Total Orders</p>
+                  <p className="mt-1 text-2xl font-bold text-gray-900">{orderMetrics.totalOrders}</p>
+                </div>
+                <div className="rounded-lg border bg-white p-4 shadow-sm">
+                  <p className="text-xs font-medium uppercase text-gray-500">Fulfilled</p>
+                  <p className="mt-1 text-2xl font-bold text-green-700">{orderMetrics.fulfilledOrders}</p>
+                </div>
+                <div className="rounded-lg border bg-white p-4 shadow-sm">
+                  <p className="text-xs font-medium uppercase text-gray-500">Avg Jobs / Order</p>
+                  <p className="mt-1 text-2xl font-bold text-gray-900">{orderMetrics.avgJobsPerOrder}</p>
+                </div>
+                <div className="rounded-lg border bg-white p-4 shadow-sm">
+                  <p className="text-xs font-medium uppercase text-gray-500">Product Types</p>
+                  <p className="mt-1 text-2xl font-bold text-gray-900">{orderMetrics.byProductType.length}</p>
+                </div>
+              </div>
+            )}
+
+            {orderMetrics && orderMetrics.byProductType.length > 0 && (
+              <div className="rounded-lg border bg-white p-6 shadow-sm">
+                <h3 className="mb-3 text-sm font-semibold text-gray-900">Fulfillment by Product Type</h3>
+                <div className="space-y-2">
+                  {orderMetrics.byProductType.map((pt) => {
+                    const pct = pt.totalQuantity > 0 ? Math.round((pt.fulfilledQuantity / pt.totalQuantity) * 100) : 0;
+                    return (
+                      <div key={pt.productType} className="flex items-center gap-3">
+                        <span className="w-24 truncate text-sm font-medium text-gray-700">{pt.productType}</span>
+                        <div className="flex h-2 flex-1 overflow-hidden rounded-full bg-gray-200">
+                          <div
+                            className="rounded-full bg-green-500 transition-all"
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                        <span className="w-20 text-right text-xs text-gray-500">
+                          {pt.fulfilledQuantity}/{pt.totalQuantity} ({pct}%)
+                        </span>
+                        <span className="w-16 text-right text-xs text-gray-400">
+                          {pt.jobCount} job{pt.jobCount !== 1 ? "s" : ""}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            <div className="rounded-lg border bg-white p-6 shadow-sm">
+              <h3 className="mb-4 text-lg font-semibold">Customer Orders</h3>
+              <CustomerOrderList
+                selectedId={selectedCustomerOrderId}
+                onSelect={(order) => setSelectedCustomerOrderId(order.id)}
+              />
+            </div>
           </div>
         )
       )}

--- a/manu-gen/frontend/src/features/dashboard/components/JobBoard.tsx
+++ b/manu-gen/frontend/src/features/dashboard/components/JobBoard.tsx
@@ -39,6 +39,7 @@ export function JobBoard({ selectedJobId, onSelectJob }: JobBoardProps) {
           <tr className="border-b text-left text-gray-500">
             <th className="py-2 pr-4 font-medium">Job</th>
             <th className="py-2 pr-4 font-medium">Product</th>
+            <th className="py-2 pr-4 font-medium">Status</th>
             <th className="py-2 pr-4 font-medium">Pipeline</th>
             <th className="py-2 pr-4 font-medium">Progress</th>
             <th className="py-2 pr-4 font-medium">Current Station</th>

--- a/manu-gen/frontend/src/features/dashboard/components/JobBoardRow.tsx
+++ b/manu-gen/frontend/src/features/dashboard/components/JobBoardRow.tsx
@@ -1,6 +1,18 @@
 import { useEffect, useState } from "react";
-import type { BoardJob, BoardJobPipeline } from "../dashboard.types";
+import type { BoardJob, BoardJobPipeline, JobStatus } from "../dashboard.types";
 import { formatDuration, parseUtc } from "../dashboard.utils";
+
+const STATUS_LABEL: Record<JobStatus, string> = {
+  pending: "Pending",
+  in_progress: "In Progress",
+  completed: "Completed",
+};
+
+const STATUS_COLOR: Record<JobStatus, string> = {
+  pending: "bg-gray-100 text-gray-700",
+  in_progress: "bg-yellow-100 text-yellow-800",
+  completed: "bg-green-100 text-green-800",
+};
 
 interface JobBoardRowProps {
   job: BoardJob;
@@ -94,6 +106,11 @@ export function JobBoardRow({ job, isSelected, onSelect }: JobBoardRowProps) {
     >
       <td className="py-3 pr-4 font-mono text-sm">{job.jobNumber}</td>
       <td className="py-3 pr-4 text-sm">{job.productType}</td>
+      <td className="py-3 pr-4 text-sm">
+        <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[job.status]}`}>
+          {STATUS_LABEL[job.status]}
+        </span>
+      </td>
       <td className="py-3 pr-4 text-sm">
         <span className="text-gray-700">{job.pipeline.name}</span>
       </td>

--- a/manu-gen/frontend/src/features/dashboard/dashboard.types.ts
+++ b/manu-gen/frontend/src/features/dashboard/dashboard.types.ts
@@ -7,12 +7,15 @@ export interface BoardJobPipeline {
   elapsedSeconds: number | null;
 }
 
+export type JobStatus = "pending" | "in_progress" | "completed";
+
 export interface BoardJob {
   id: number;
   jobNumber: string;
   productType: string;
   trayCode: string;
   createdAt: string;
+  status: JobStatus;
   currentStation: { id: string; name: string } | null;
   lastSeenAt: string | null;
   stationArrivedAt: string | null;

--- a/manu-gen/frontend/src/features/dashboard/hooks/useOrderMetrics.ts
+++ b/manu-gen/frontend/src/features/dashboard/hooks/useOrderMetrics.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+
+export interface ProductTypeMetric {
+  productType: string;
+  totalQuantity: number;
+  fulfilledQuantity: number;
+  jobCount: number;
+}
+
+export interface OrderMetrics {
+  totalOrders: number;
+  fulfilledOrders: number;
+  avgJobsPerOrder: number;
+  byProductType: ProductTypeMetric[];
+}
+
+export function useOrderMetrics() {
+  return useQuery<OrderMetrics>({
+    queryKey: ["analytics", "order-metrics"],
+    queryFn: () => apiClient.get<OrderMetrics>("/analytics/order-metrics"),
+    refetchInterval: 10_000,
+  });
+}

--- a/manu-gen/frontend/src/features/jobs/components/JobForm.test.tsx
+++ b/manu-gen/frontend/src/features/jobs/components/JobForm.test.tsx
@@ -19,13 +19,13 @@ describe("JobForm", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(usePipelines).mockReturnValue({
-      data: [{ id: "pipeline-1", name: "Pipeline A", steps: [{ stationId: "s1", maxDurationSeconds: 60 }], description: "", totalExpectedSeconds: 60, createdAt: "" }],
+      data: [{ id: "pipeline-1", name: "Pipeline A", productType: "Widget", steps: [{ stationId: "s1", maxDurationSeconds: 60 }], description: "", totalExpectedSeconds: 60, effectiveCapacity: 20, createdAt: "" }],
       isLoading: false,
       error: null,
     } as unknown as ReturnType<typeof usePipelines>);
   });
 
-  it("should render product type, quantity, pipeline, and notes fields", () => {
+  it("should render pipeline, quantity, and notes fields", () => {
     vi.mocked(useCreateJob).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
@@ -34,27 +34,21 @@ describe("JobForm", () => {
 
     render(<JobForm onJobCreated={vi.fn()} />, { wrapper: createWrapper() });
 
-    expect(screen.getByLabelText("Product Type")).toBeInTheDocument();
-    expect(screen.getByLabelText("Quantity")).toBeInTheDocument();
     expect(screen.getByLabelText("Pipeline")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Quantity/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Create Job" })).toBeInTheDocument();
   });
 
-  it("should show validation error when product type is empty", async () => {
+  it("should disable submit button when no pipeline is selected", () => {
     vi.mocked(useCreateJob).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
       error: null,
     } as unknown as ReturnType<typeof useCreateJob>);
 
-    const user = userEvent.setup();
     render(<JobForm onJobCreated={vi.fn()} />, { wrapper: createWrapper() });
 
-    await user.click(screen.getByRole("button", { name: "Create Job" }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/Product type is required/i)).toBeInTheDocument();
-    });
+    expect(screen.getByRole("button", { name: "Create Job" })).toBeDisabled();
   });
 
   it("should display server error", () => {

--- a/manu-gen/frontend/src/features/jobs/components/JobForm.test.tsx
+++ b/manu-gen/frontend/src/features/jobs/components/JobForm.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import { createWrapper } from "../../../test-utils";
 import { JobForm } from "./JobForm";

--- a/manu-gen/frontend/src/features/jobs/components/JobForm.tsx
+++ b/manu-gen/frontend/src/features/jobs/components/JobForm.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createJobSchema, type CreateJobFormValues } from "../jobs.schema";
@@ -15,10 +16,11 @@ export function JobForm({ onJobCreated }: JobFormProps) {
     handleSubmit,
     reset,
     watch,
+    setValue,
     formState: { errors },
   } = useForm<CreateJobFormValues>({
     resolver: zodResolver(createJobSchema),
-    defaultValues: { pipelineId: "" },
+    defaultValues: { pipelineId: "", productType: "" },
   });
 
   const { mutate, isPending, error } = useCreateJob();
@@ -26,6 +28,14 @@ export function JobForm({ onJobCreated }: JobFormProps) {
 
   const selectedPipelineId = watch("pipelineId");
   const selectedPipeline = pipelines?.find((p) => p.id === selectedPipelineId);
+
+  useEffect(() => {
+    if (selectedPipeline?.productType) {
+      setValue("productType", selectedPipeline.productType);
+    } else {
+      setValue("productType", "");
+    }
+  }, [selectedPipelineId, selectedPipeline, setValue]);
 
   function onSubmit(values: CreateJobFormValues) {
     mutate(values, {
@@ -41,38 +51,6 @@ export function JobForm({ onJobCreated }: JobFormProps) {
       <h2 className="text-lg font-semibold">New Job</h2>
 
       <div className="flex flex-col gap-1">
-        <label htmlFor="productType" className="text-sm font-medium">
-          Product Type
-        </label>
-        <input
-          id="productType"
-          {...register("productType")}
-          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          placeholder="Widget A"
-        />
-        {errors.productType && (
-          <p className="text-xs text-red-600">{errors.productType.message}</p>
-        )}
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <label htmlFor="quantity" className="text-sm font-medium">
-          Quantity
-        </label>
-        <input
-          id="quantity"
-          type="number"
-          min={1}
-          {...register("quantity", { valueAsNumber: true })}
-          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          placeholder="1"
-        />
-        {errors.quantity && (
-          <p className="text-xs text-red-600">{errors.quantity.message}</p>
-        )}
-      </div>
-
-      <div className="flex flex-col gap-1">
         <label htmlFor="pipelineId" className="text-sm font-medium">
           Pipeline
         </label>
@@ -85,7 +63,9 @@ export function JobForm({ onJobCreated }: JobFormProps) {
         >
           <option value="">Select a pipeline...</option>
           {pipelines?.map((p) => (
-            <option key={p.id} value={p.id}>{p.name}</option>
+            <option key={p.id} value={p.id}>
+              {p.name}{p.productType ? ` (${p.productType})` : ""}
+            </option>
           ))}
         </select>
         {errors.pipelineId && (
@@ -93,11 +73,43 @@ export function JobForm({ onJobCreated }: JobFormProps) {
         )}
         {selectedPipeline && (
           <p className="text-xs text-gray-400">
+            {selectedPipeline.productType && (
+              <span>Product: {selectedPipeline.productType} &middot; </span>
+            )}
             {selectedPipeline.steps.length} step{selectedPipeline.steps.length !== 1 ? "s" : ""}
             {selectedPipeline.totalExpectedSeconds !== null && (
               <span> &middot; ~{Math.round(selectedPipeline.totalExpectedSeconds / 60)}m expected</span>
             )}
+            {selectedPipeline.effectiveCapacity !== null && (
+              <span> &middot; max {selectedPipeline.effectiveCapacity} items/tray</span>
+            )}
           </p>
+        )}
+      </div>
+
+      <input type="hidden" {...register("productType")} />
+      {errors.productType && (
+        <p className="text-xs text-red-600">Select a pipeline to set the product type</p>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="quantity" className="text-sm font-medium">
+          Quantity
+          {selectedPipeline?.effectiveCapacity !== null && selectedPipeline?.effectiveCapacity !== undefined && (
+            <span className="ml-1 font-normal text-gray-400">(max {selectedPipeline.effectiveCapacity})</span>
+          )}
+        </label>
+        <input
+          id="quantity"
+          type="number"
+          min={1}
+          max={selectedPipeline?.effectiveCapacity ?? undefined}
+          {...register("quantity", { valueAsNumber: true })}
+          className="rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="1"
+        />
+        {errors.quantity && (
+          <p className="text-xs text-red-600">{errors.quantity.message}</p>
         )}
       </div>
 
@@ -120,7 +132,7 @@ export function JobForm({ onJobCreated }: JobFormProps) {
 
       <button
         type="submit"
-        disabled={isPending}
+        disabled={isPending || !selectedPipeline}
         className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
       >
         {isPending ? "Creating…" : "Create Job"}

--- a/manu-gen/frontend/src/features/jobs/components/JobList.tsx
+++ b/manu-gen/frontend/src/features/jobs/components/JobList.tsx
@@ -1,5 +1,18 @@
 import { useJobs } from "../hooks/useJobs";
-import type { Job } from "../jobs.types";
+import { useDeleteJob } from "../hooks/useDeleteJob";
+import type { Job, JobStatus } from "../jobs.types";
+
+const STATUS_LABEL: Record<JobStatus, string> = {
+  pending: "Pending",
+  in_progress: "In Progress",
+  completed: "Completed",
+};
+
+const STATUS_COLOR: Record<JobStatus, string> = {
+  pending: "bg-gray-100 text-gray-700",
+  in_progress: "bg-yellow-100 text-yellow-800",
+  completed: "bg-green-100 text-green-800",
+};
 
 interface JobListProps {
   selectedJobId: number | null;
@@ -8,6 +21,7 @@ interface JobListProps {
 
 export function JobList({ selectedJobId, onSelectJob }: JobListProps) {
   const { data, isLoading, error } = useJobs();
+  const deleteMutation = useDeleteJob();
 
   if (isLoading) {
     return <p className="text-sm text-gray-500">Loading jobs…</p>;
@@ -34,8 +48,11 @@ export function JobList({ selectedJobId, onSelectJob }: JobListProps) {
             <th className="py-2 pr-4 font-medium">Product</th>
             <th className="py-2 pr-4 font-medium">Pipeline</th>
             <th className="py-2 pr-4 font-medium">Qty</th>
+            <th className="py-2 pr-4 font-medium">Allocated</th>
+            <th className="py-2 pr-4 font-medium">Status</th>
             <th className="py-2 pr-4 font-medium">Tray Code</th>
-            <th className="py-2 font-medium">Created At</th>
+            <th className="py-2 pr-4 font-medium">Created At</th>
+            <th className="py-2 font-medium"></th>
           </tr>
         </thead>
         <tbody>
@@ -59,9 +76,39 @@ export function JobList({ selectedJobId, onSelectJob }: JobListProps) {
               <td className="py-2 pr-4">{job.productType}</td>
               <td className="py-2 pr-4">{job.pipelineName}</td>
               <td className="py-2 pr-4">{job.quantity}</td>
+              <td className="py-2 pr-4">
+                {job.allocatedQuantity === 0 ? (
+                  <span className="inline-block rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-800">
+                    Unassigned
+                  </span>
+                ) : (
+                  <span className="text-xs text-gray-600">
+                    {job.allocatedQuantity} / {job.quantity}
+                  </span>
+                )}
+              </td>
+              <td className="py-2 pr-4">
+                <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[job.status]}`}>
+                  {STATUS_LABEL[job.status]}
+                </span>
+              </td>
               <td className="py-2 pr-4 font-mono">{job.trayCode}</td>
-              <td className="py-2">
+              <td className="py-2 pr-4">
                 {new Date(job.createdAt).toLocaleString()}
+              </td>
+              <td className="py-2">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (confirm(`Delete ${job.jobNumber}? This will also remove its allocations and tracking events.`)) {
+                      deleteMutation.mutate(job.id);
+                    }
+                  }}
+                  className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+                >
+                  Delete
+                </button>
               </td>
             </tr>
           ))}

--- a/manu-gen/frontend/src/features/jobs/hooks/useCreateJob.test.ts
+++ b/manu-gen/frontend/src/features/jobs/hooks/useCreateJob.test.ts
@@ -22,6 +22,7 @@ const sampleJob: Job = {
   notes: "",
   trayCode: "TRAY-0001",
   createdAt: "2026-01-01T00:00:00.000Z",
+  status: "pending",
   pipelineId: "pipeline-abc",
   pipelineName: "Test Pipeline",
 };

--- a/manu-gen/frontend/src/features/jobs/hooks/useDeleteJob.ts
+++ b/manu-gen/frontend/src/features/jobs/hooks/useDeleteJob.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../../../shared/api/client";
+
+export function useDeleteJob() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => apiClient.delete(`/jobs/${id}`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    },
+  });
+}

--- a/manu-gen/frontend/src/features/jobs/hooks/useJobs.test.ts
+++ b/manu-gen/frontend/src/features/jobs/hooks/useJobs.test.ts
@@ -22,6 +22,7 @@ const sampleJobs: Job[] = [
     notes: "",
     trayCode: "TRAY-0001",
     createdAt: "2026-01-01T00:00:00.000Z",
+    status: "pending",
     pipelineId: "pipeline-abc",
     pipelineName: "Test Pipeline",
   },

--- a/manu-gen/frontend/src/features/jobs/jobs.types.ts
+++ b/manu-gen/frontend/src/features/jobs/jobs.types.ts
@@ -1,3 +1,5 @@
+export type JobStatus = "pending" | "in_progress" | "completed";
+
 export interface Job {
   id: number;
   jobNumber: string;
@@ -9,6 +11,7 @@ export interface Job {
   createdAt: string;
   pipelineId: string;
   pipelineName: string;
+  status: JobStatus;
 }
 
 export type JobsResponse = Job[];

--- a/manu-gen/frontend/src/features/pipelines/components/CreatePipelineForm.tsx
+++ b/manu-gen/frontend/src/features/pipelines/components/CreatePipelineForm.tsx
@@ -7,8 +7,9 @@ import type { StepFormValue } from "../pipelines.schema";
 export function CreatePipelineForm() {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [productType, setProductType] = useState("");
   const [steps, setSteps] = useState<StepFormValue[]>([
-    { stationId: "", maxDurationSeconds: null },
+    { stationId: "", maxDurationSeconds: null, maxCapacity: null },
   ]);
   const [submitted, setSubmitted] = useState(false);
 
@@ -16,6 +17,7 @@ export function CreatePipelineForm() {
   const { data: stations } = useStations();
 
   const nameError = submitted && name.trim().length === 0;
+  const productTypeError = submitted && productType.trim().length === 0;
   const validSteps = steps.filter((s) => s.stationId.length > 0);
   const stepsError = submitted && validSteps.length === 0;
 
@@ -24,15 +26,17 @@ export function CreatePipelineForm() {
     setSubmitted(true);
 
     const trimmedName = name.trim();
-    if (trimmedName.length === 0 || validSteps.length === 0) return;
+    const trimmedProductType = productType.trim();
+    if (trimmedName.length === 0 || trimmedProductType.length === 0 || validSteps.length === 0) return;
 
     createPipeline.mutate(
-      { name: trimmedName, description: description.trim(), steps: validSteps },
+      { name: trimmedName, description: description.trim(), productType: trimmedProductType, steps: validSteps },
       {
         onSuccess: () => {
           setName("");
           setDescription("");
-          setSteps([{ stationId: "", maxDurationSeconds: null }]);
+          setProductType("");
+          setSteps([{ stationId: "", maxDurationSeconds: null, maxCapacity: null }]);
           setSubmitted(false);
         },
       },
@@ -41,7 +45,7 @@ export function CreatePipelineForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4" noValidate>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div>
           <label htmlFor="pipeline-name" className="mb-1 block text-sm font-medium text-gray-700">
             Name
@@ -59,6 +63,25 @@ export function CreatePipelineForm() {
           />
           {nameError && (
             <p className="mt-1 text-xs text-red-600">Pipeline name is required.</p>
+          )}
+        </div>
+        <div>
+          <label htmlFor="pipeline-product-type" className="mb-1 block text-sm font-medium text-gray-700">
+            Product Type
+          </label>
+          <input
+            id="pipeline-product-type"
+            type="text"
+            value={productType}
+            onChange={(e) => setProductType(e.target.value)}
+            placeholder="e.g. Widget"
+            aria-invalid={productTypeError}
+            className={`w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              productTypeError ? "border-red-400 ring-1 ring-red-400" : ""
+            }`}
+          />
+          {productTypeError && (
+            <p className="mt-1 text-xs text-red-600">Product type is required.</p>
           )}
         </div>
         <div>

--- a/manu-gen/frontend/src/features/pipelines/components/PipelineCard.tsx
+++ b/manu-gen/frontend/src/features/pipelines/components/PipelineCard.tsx
@@ -23,6 +23,7 @@ export function PipelineCard({ pipeline }: PipelineCardProps) {
     pipeline.steps.map((s) => ({
       stationId: s.stationId,
       maxDurationSeconds: s.maxDurationSeconds,
+      maxCapacity: s.maxCapacity,
     })),
   );
 
@@ -55,6 +56,7 @@ export function PipelineCard({ pipeline }: PipelineCardProps) {
       pipeline.steps.map((s) => ({
         stationId: s.stationId,
         maxDurationSeconds: s.maxDurationSeconds,
+        maxCapacity: s.maxCapacity,
       })),
     );
     setEditing(false);
@@ -66,7 +68,14 @@ export function PipelineCard({ pipeline }: PipelineCardProps) {
     <div className="rounded-lg border bg-white p-5 shadow-sm">
       <div className="mb-3 flex items-start justify-between">
         <div>
-          <h3 className="font-semibold text-gray-900">{pipeline.name}</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-gray-900">{pipeline.name}</h3>
+            {pipeline.productType && (
+              <span className="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+                {pipeline.productType}
+              </span>
+            )}
+          </div>
           {pipeline.description && (
             <p className="text-sm text-gray-500">{pipeline.description}</p>
           )}
@@ -74,6 +83,9 @@ export function PipelineCard({ pipeline }: PipelineCardProps) {
             {pipeline.steps.length} step{pipeline.steps.length !== 1 ? "s" : ""}
             {pipeline.totalExpectedSeconds !== null && (
               <span> &middot; ~{formatMinutes(pipeline.totalExpectedSeconds)} expected</span>
+            )}
+            {pipeline.effectiveCapacity !== null && (
+              <span> &middot; max {pipeline.effectiveCapacity} items/tray</span>
             )}
           </p>
         </div>
@@ -126,6 +138,9 @@ export function PipelineCard({ pipeline }: PipelineCardProps) {
                   {step.stationName}
                   {step.maxDurationSeconds !== null && (
                     <span className="ml-1 text-gray-400">{formatMinutes(step.maxDurationSeconds)}</span>
+                  )}
+                  {step.maxCapacity !== null && (
+                    <span className="ml-1 text-gray-400">/{step.maxCapacity}</span>
                   )}
                 </span>
               </div>

--- a/manu-gen/frontend/src/features/pipelines/components/PipelineStepEditor.tsx
+++ b/manu-gen/frontend/src/features/pipelines/components/PipelineStepEditor.tsx
@@ -31,8 +31,18 @@ export function PipelineStepEditor({ steps, stations, onChange }: PipelineStepEd
     onChange(next);
   }
 
+  function handleCapacityChange(index: number, raw: string) {
+    const next = [...steps];
+    const val = raw.trim() === "" ? null : Number(raw);
+    next[index] = {
+      ...next[index],
+      maxCapacity: val !== null && !isNaN(val) && val > 0 ? val : null,
+    };
+    onChange(next);
+  }
+
   function handleAdd() {
-    onChange([...steps, { stationId: "", maxDurationSeconds: null }]);
+    onChange([...steps, { stationId: "", maxDurationSeconds: null, maxCapacity: null }]);
   }
 
   function handleRemove(index: number) {
@@ -92,6 +102,17 @@ export function PipelineStepEditor({ steps, stations, onChange }: PipelineStepEd
               placeholder="min"
               className="w-20 shrink-0 rounded border px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               title="Expected duration in minutes"
+            />
+
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={step.maxCapacity ?? ""}
+              onChange={(e) => handleCapacityChange(index, e.target.value)}
+              placeholder="cap"
+              className="w-16 shrink-0 rounded border px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              title="Max items per tray"
             />
 
             <div className="flex gap-0.5">

--- a/manu-gen/frontend/src/features/pipelines/pipelines.schema.ts
+++ b/manu-gen/frontend/src/features/pipelines/pipelines.schema.ts
@@ -1,16 +1,16 @@
 import { z } from "zod";
 
+const stepSchema = z.object({
+  stationId: z.string().min(1, "Station is required"),
+  maxDurationSeconds: z.number().int().min(1).nullable().optional().default(null),
+  maxCapacity: z.number().int().min(1).nullable().optional().default(null),
+});
+
 export const createPipelineSchema = z.object({
   name: z.string().min(1, "Name is required"),
   description: z.string().optional().default(""),
-  steps: z
-    .array(
-      z.object({
-        stationId: z.string().min(1, "Station is required"),
-        maxDurationSeconds: z.number().int().min(1).nullable().optional().default(null),
-      }),
-    )
-    .min(1, "At least one step is required"),
+  productType: z.string().min(1, "Product type is required"),
+  steps: z.array(stepSchema).min(1, "At least one step is required"),
 });
 
 export type CreatePipelineFormValues = z.infer<typeof createPipelineSchema>;

--- a/manu-gen/frontend/src/features/pipelines/pipelines.types.ts
+++ b/manu-gen/frontend/src/features/pipelines/pipelines.types.ts
@@ -4,13 +4,16 @@ export interface PipelineStep {
   stationName: string;
   position: number;
   maxDurationSeconds: number | null;
+  maxCapacity: number | null;
 }
 
 export interface Pipeline {
   id: string;
   name: string;
   description: string;
+  productType: string;
   createdAt: string;
   steps: PipelineStep[];
   totalExpectedSeconds: number | null;
+  effectiveCapacity: number | null;
 }


### PR DESCRIPTION
## Summary
- Introduces pipeline-level capacity constraints and automatic job creation/allocation when customer orders are placed, significantly reducing manual work for order fulfillment.

## Changes

### Pipeline capacity
- Pipeline steps now support `maxCapacity` (max items per station per tray)
- `effectiveCapacity` = min capacity across all pipeline steps
- Frontend pipeline editor gains a capacity input per step; pipeline cards display capacity info

### Auto-allocation on order creation
- When a customer order is created, `autoCreateAndAllocate` packs into existing pending jobs (respecting unallocated space) before creating new ones
- Jobs are auto-sized to pipeline capacity; allocations are inserted atomically within the order creation transaction

### Job management
- Manual job creation validates product type matches pipeline and quantity does not exceed capacity
- Job form auto-fills product type from selected pipeline; quantity capped at effective capacity
- `DELETE /jobs/:id` with cascade (allocations + tracking events); 409 guard for in-progress jobs unless `?force=true`
- Jobs view shows allocation status ("Unassigned" badge or allocated/total)

### Customer order management
- `DELETE /customer-orders/:id` with intelligent cascade: deletes exclusively-serving jobs, shrinks shared jobs, removes allocations and order lines
- Order list gains a delete button; creating an order now invalidates the jobs cache too

### Dashboard & analytics
- New order metrics endpoint (`GET /analytics/order-metrics`): total/fulfilled orders, avg jobs per order, fulfillment by product type
- Dashboard "Customer Orders" tab displays order metrics cards and fulfillment-by-product-type bar chart
- `CustomerOrderDetail` gains an "Order Summary" table showing requested/allocated/fulfilled per line

### Type safety
- Zod schema input types (`CreateJobInput`, `CreateCustomerOrderInput`, `CreatePipelineInput`, `CreateStationInput`) changed from `z.infer` to `z.input` so callers that skip `.parse()` are not forced to provide fields with `.default()` values

## Test plan
- [x] Backend: 194 tests passing (`npx vitest run`)
- [x] Backend: `tsc --noEmit` clean
- [x] Frontend: `tsc --noEmit` clean
- [x] Job creation validates capacity and product type (3 new service tests, 4 new controller tests)
- [x] Job deletion cascades correctly (3 new service tests, 4 new controller tests)
- [x] Customer order deletion: exclusive job removal, shared job shrinkage, cascade allocations (5 tests)
- [x] Auto-allocation: packing into existing jobs, multi-job creation, in-progress exclusion, multi-product-type orders (7 tests)


Made with [Cursor](https://cursor.com)