### PR TITLE
feat(frontend): Jobs list empty states and toolbar count

### DIFF
--- a/manu-gen/frontend/src/features/jobs/components/JobList.module.css
+++ b/manu-gen/frontend/src/features/jobs/components/JobList.module.css
@@ -8,9 +8,72 @@
   color: var(--status-late);
 }
 
-.empty {
-  font-size: var(--text-sm);
+/* Empty list — same visual pattern as PipelineList / StationList (icon + copy), inside All Jobs card. */
+.emptyState {
+  padding: var(--space-12) var(--space-6);
+  text-align: center;
+}
+
+.emptyIcon {
+  display: block;
+  margin: 0 auto var(--space-4);
   color: var(--text-muted);
+}
+
+.emptyHeading {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-heading);
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  line-height: 1.25;
+  color: var(--text);
+}
+
+.emptyText {
+  margin: 0 auto;
+  max-width: 36em;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.emptyStrong {
+  font-weight: var(--weight-semibold);
+  color: var(--text-secondary);
+}
+
+.emptyActions {
+  margin-top: var(--space-6);
+}
+
+.emptyCta {
+  display: inline-flex;
+  height: var(--btn-height);
+  align-items: center;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  padding: 0 var(--space-4);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--easing-default),
+    border-color var(--duration-fast) var(--easing-default),
+    color var(--duration-fast) var(--easing-default);
+}
+
+.emptyCta:hover {
+  background: var(--surface-hover);
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.emptyCta:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .scroll {

--- a/manu-gen/frontend/src/features/jobs/components/JobList.test.tsx
+++ b/manu-gen/frontend/src/features/jobs/components/JobList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import { createWrapper } from "../../../test-utils";
@@ -52,6 +52,22 @@ describe("JobList", () => {
     expect(screen.getByText(/Failed to load jobs/)).toBeInTheDocument();
   });
 
+  it("should show loading when jobs are undefined but not in error (query gap)", () => {
+    render(
+      <JobList
+        jobs={undefined}
+        jobsLoading={false}
+        jobsError={null}
+        filter="all"
+        onViewJob={vi.fn()}
+        onPrintJob={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText(/Loading jobs/)).toBeInTheDocument();
+  });
+
   it("should show empty state when no jobs exist", () => {
     render(
       <JobList
@@ -65,7 +81,53 @@ describe("JobList", () => {
       { wrapper: createWrapper() },
     );
 
-    expect(screen.getByText(/No jobs yet/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /No jobs yet/i })).toBeInTheDocument();
+    expect(screen.getByText(/page header/i)).toBeInTheDocument();
+  });
+
+  it("should show filtered empty state when jobs exist but none match the tab, and call onShowAllJobs", async () => {
+    const user = userEvent.setup();
+    const onShowAllJobs = vi.fn();
+
+    render(
+      <JobList
+        jobs={[sampleJob]}
+        jobsLoading={false}
+        jobsError={null}
+        filter="in_progress"
+        onViewJob={vi.fn()}
+        onPrintJob={vi.fn()}
+        onShowAllJobs={onShowAllJobs}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const region = screen.getByRole("status");
+    expect(within(region).getByRole("heading", { name: /No In Progress jobs/i })).toBeInTheDocument();
+    expect(within(region).getByText(/You have 1 job, but none are/i)).toBeInTheDocument();
+    expect(within(region).getByText("In Progress")).toBeInTheDocument();
+    await user.click(within(region).getByRole("button", { name: /View all jobs/i }));
+    expect(onShowAllJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it("should pluralize job count in filtered empty state", () => {
+    const second: Job = { ...sampleJob, id: 2, jobNumber: "JOB-0002" };
+
+    render(
+      <JobList
+        jobs={[sampleJob, second]}
+        jobsLoading={false}
+        jobsError={null}
+        filter="completed"
+        onViewJob={vi.fn()}
+        onPrintJob={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(
+      within(screen.getByRole("status")).getByText(/You have 2 jobs, but none are/i),
+    ).toBeInTheDocument();
   });
 
   it("should render job rows", () => {

--- a/manu-gen/frontend/src/features/jobs/components/JobList.tsx
+++ b/manu-gen/frontend/src/features/jobs/components/JobList.tsx
@@ -1,6 +1,7 @@
-import { Printer } from "lucide-react";
-import type { Job } from "../jobs.types";
+import { PackageOpen, Printer } from "lucide-react";
+import type { Job, JobStatus } from "../jobs.types";
 import { filterJobsByTab, type JobsTableFilter } from "./jobListFilters";
+import { filteredEmptyHeadline, JOB_STATUS_LABEL } from "./jobStatusLabels";
 import { JobStatusBadge } from "./JobStatusBadge";
 import styles from "./JobList.module.css";
 
@@ -19,6 +20,8 @@ interface JobListProps {
   filter: JobsTableFilter;
   onViewJob: (job: Job) => void;
   onPrintJob: (job: Job) => void;
+  /** Resets the status filter to “All” when the tab hides every job. Jobs list page should pass this. */
+  onShowAllJobs?: () => void;
 }
 
 export function JobList({
@@ -28,26 +31,75 @@ export function JobList({
   filter,
   onViewJob,
   onPrintJob,
+  onShowAllJobs,
 }: JobListProps) {
-  if (jobsLoading) {
-    return <p className={styles.loading}>Loading jobs…</p>;
-  }
-
+  /**
+   * Error takes priority over loading so the user sees the failure, even during a refetch
+   * (TanStack Query can keep a stale error while `isFetching` is true). This is intentional:
+   * we prefer showing "Failed" + retry over masking errors behind a spinner.
+   */
   if (jobsError) {
     return (
       <p className={styles.error}>Failed to load jobs: {jobsErrorMessage(jobsError)}</p>
     );
   }
 
-  const jobs = filterJobsByTab(jobsData ?? [], filter);
-
-  if ((jobsData ?? []).length === 0) {
-    return <p className={styles.empty}>No jobs yet. Create one with Create Job manually.</p>;
+  if (jobsLoading || jobsData === undefined) {
+    return <p className={styles.loading}>Loading jobs…</p>;
   }
 
-  if (jobs.length === 0) {
+  const jobs = filterJobsByTab(jobsData, filter);
+
+  if (jobsData.length === 0) {
     return (
-      <p className={styles.empty}>No jobs match this filter. Try another tab or clear the filter.</p>
+      <div className={styles.emptyState} role="status" aria-live="polite">
+        <PackageOpen size={40} strokeWidth={1.5} className={styles.emptyIcon} aria-hidden />
+        <h2 className={styles.emptyHeading}>No jobs yet</h2>
+        <p className={styles.emptyText}>
+          Jobs are created when you save a customer order—one per line item. Use{" "}
+          <strong className={styles.emptyStrong}>Create Job manually</strong> in the page header only
+          if you need a job outside the order flow.
+        </p>
+      </div>
+    );
+  }
+
+  /** Jobs exist, but the status tab excludes every row (`filter` cannot be `"all"` here). */
+  if (jobs.length === 0) {
+    if (filter === "all") {
+      if (import.meta.env.DEV) {
+        console.error(
+          "[JobList] Invariant violated: empty filtered list with filter “all” while jobs exist.",
+        );
+      }
+      return (
+        <p className={styles.error} role="alert">
+          Unable to display the job list. Try refreshing the page.
+        </p>
+      );
+    }
+
+    const status: JobStatus = filter;
+    const totalJobs = jobsData.length;
+    const statusLabel = JOB_STATUS_LABEL[status];
+
+    return (
+      <div className={styles.emptyState} role="status" aria-live="polite">
+        <PackageOpen size={40} strokeWidth={1.5} className={styles.emptyIcon} aria-hidden />
+        <h2 className={styles.emptyHeading}>{filteredEmptyHeadline(status)}</h2>
+        <p className={styles.emptyText}>
+          You have {totalJobs} {totalJobs === 1 ? "job" : "jobs"}, but none are{" "}
+          <strong className={styles.emptyStrong}>{statusLabel}</strong> right now. Try another tab
+          {onShowAllJobs ? ", or view all jobs." : "."}
+        </p>
+        {onShowAllJobs && (
+          <div className={styles.emptyActions}>
+            <button type="button" className={styles.emptyCta} onClick={onShowAllJobs}>
+              View all jobs
+            </button>
+          </div>
+        )}
+      </div>
     );
   }
 

--- a/manu-gen/frontend/src/features/jobs/components/JobsListView.test.tsx
+++ b/manu-gen/frontend/src/features/jobs/components/JobsListView.test.tsx
@@ -46,4 +46,36 @@ describe("JobsListView", () => {
     expect(allBtn).toHaveAttribute("aria-pressed", "false");
     expect(pendingBtn).toHaveAttribute("aria-pressed", "true");
   });
+
+  it("shows an em dash instead of a count while data is loading", () => {
+    render(
+      <JobsListView
+        jobs={undefined}
+        jobsLoading
+        jobsError={null}
+        onCreateManual={vi.fn()}
+        onViewJob={vi.fn()}
+        onPrintJob={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("— jobs")).toBeInTheDocument();
+  });
+
+  it("shows the numeric count once data is available", () => {
+    render(
+      <JobsListView
+        jobs={[sampleJob]}
+        jobsLoading={false}
+        jobsError={null}
+        onCreateManual={vi.fn()}
+        onViewJob={vi.fn()}
+        onPrintJob={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("1 job")).toBeInTheDocument();
+  });
 });

--- a/manu-gen/frontend/src/features/jobs/components/JobsListView.tsx
+++ b/manu-gen/frontend/src/features/jobs/components/JobsListView.tsx
@@ -5,13 +5,15 @@ import type { Job } from "../jobs.types";
 import { JobList, type JobsTableFilter } from "./JobList";
 import { JobsFallbackNote } from "./JobsFallbackNote";
 import { filterJobsByTab } from "./jobListFilters";
+import { JOB_STATUS_FILTER_ORDER, JOB_STATUS_LABEL } from "./jobStatusLabels";
 import styles from "./JobsListView.module.css";
 
 const TABS: { id: JobsTableFilter; label: string }[] = [
   { id: "all", label: "All" },
-  { id: "pending", label: "Pending" },
-  { id: "in_progress", label: "In Progress" },
-  { id: "completed", label: "Completed" },
+  ...JOB_STATUS_FILTER_ORDER.map((id) => ({
+    id,
+    label: JOB_STATUS_LABEL[id],
+  })),
 ];
 
 interface JobsListViewProps {
@@ -33,9 +35,11 @@ export function JobsListView({
 }: JobsListViewProps) {
   const [filter, setFilter] = useState<JobsTableFilter>("all");
 
+  const hasData = jobs !== undefined;
+
   const filteredCount = useMemo(
-    () => filterJobsByTab(jobs ?? [], filter).length,
-    [jobs, filter],
+    () => (hasData ? filterJobsByTab(jobs, filter).length : null),
+    [hasData, jobs, filter],
   );
 
   return (
@@ -72,7 +76,9 @@ export function JobsListView({
                 ))}
               </div>
               <span className={styles.count}>
-                {filteredCount} {filteredCount === 1 ? "job" : "jobs"}
+                {filteredCount !== null
+                  ? `${filteredCount} ${filteredCount === 1 ? "job" : "jobs"}`
+                  : "— jobs"}
               </span>
             </div>
           </div>
@@ -84,6 +90,7 @@ export function JobsListView({
             filter={filter}
             onViewJob={onViewJob}
             onPrintJob={onPrintJob}
+            onShowAllJobs={() => setFilter("all")}
           />
         </div>
       </div>

--- a/manu-gen/frontend/src/features/jobs/components/jobListFilters.test.ts
+++ b/manu-gen/frontend/src/features/jobs/components/jobListFilters.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { Job } from "../jobs.types";
+import { filterJobsByTab } from "./jobListFilters";
+
+const j = (status: Job["status"]): Job => ({
+  id: 1,
+  jobNumber: "J1",
+  productType: "P",
+  quantity: 1,
+  allocatedQuantity: 0,
+  notes: "",
+  trayCode: "T",
+  createdAt: "",
+  pipelineId: "pl",
+  pipelineName: "Pl",
+  status,
+});
+
+describe("filterJobsByTab", () => {
+  const jobs: Job[] = [j("pending"), { ...j("pending"), id: 2, status: "in_progress" }];
+
+  it("returns all jobs when filter is all", () => {
+    expect(filterJobsByTab(jobs, "all")).toHaveLength(2);
+  });
+
+  it("filters by status", () => {
+    expect(filterJobsByTab(jobs, "pending")).toHaveLength(1);
+    expect(filterJobsByTab(jobs, "pending")[0].status).toBe("pending");
+    expect(filterJobsByTab(jobs, "completed")).toHaveLength(0);
+  });
+});

--- a/manu-gen/frontend/src/features/jobs/components/jobStatusLabels.test.ts
+++ b/manu-gen/frontend/src/features/jobs/components/jobStatusLabels.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { filteredEmptyHeadline, JOB_STATUS_LABEL, JOB_STATUS_FILTER_ORDER } from "./jobStatusLabels";
+
+describe("jobStatusLabels", () => {
+  it("derives filtered-empty headlines from tab labels", () => {
+    const statuses = Object.keys(JOB_STATUS_LABEL) as (keyof typeof JOB_STATUS_LABEL)[];
+    for (const s of statuses) {
+      expect(filteredEmptyHeadline(s)).toBe(`No ${JOB_STATUS_LABEL[s]} jobs`);
+    }
+  });
+
+  it("includes every JobStatus exactly once in filter order", () => {
+    const labelKeys = Object.keys(JOB_STATUS_LABEL);
+    const orderSet = new Set<string>(JOB_STATUS_FILTER_ORDER);
+
+    expect(JOB_STATUS_FILTER_ORDER.length).toBe(labelKeys.length);
+    expect(orderSet.size).toBe(JOB_STATUS_FILTER_ORDER.length);
+
+    for (const s of labelKeys) {
+      expect(orderSet.has(s)).toBe(true);
+    }
+  });
+});

--- a/manu-gen/frontend/src/features/jobs/components/jobStatusLabels.ts
+++ b/manu-gen/frontend/src/features/jobs/components/jobStatusLabels.ts
@@ -1,7 +1,23 @@
 import type { JobStatus } from "../jobs.types";
 
+/** Tab labels, table emphasis, and filtered-empty headlines — single source for status wording. */
 export const JOB_STATUS_LABEL: Record<JobStatus, string> = {
   pending: "Pending",
   in_progress: "In Progress",
   completed: "Completed",
 };
+
+/**
+ * Segment order for the Jobs list filter (the "All" tab is prepended in `JobsListView`).
+ * Typed as a tuple so TypeScript errors if a status is missing or duplicated.
+ */
+export const JOB_STATUS_FILTER_ORDER: readonly [
+  "pending",
+  "in_progress",
+  "completed",
+] = ["pending", "in_progress", "completed"];
+
+/** e.g. "No Pending jobs", "No In Progress jobs" — matches tab labels in `JOB_STATUS_LABEL`. */
+export function filteredEmptyHeadline(status: JobStatus): string {
+  return `No ${JOB_STATUS_LABEL[status]} jobs`;
+}


### PR DESCRIPTION
## Summary
Improves the Jobs list when it is empty or when status filters hide every job, and fixes the toolbar showing a misleading **0 jobs** while the query is still loading.

## Changes
- **Empty states:** Centered layout (icon, heading, body) aligned with Pipelines/Stations; separate copy for *no jobs in the system* vs *jobs exist but none match the current tab*, including count and **View all jobs**.
- **Toolbar count:** Shows **— jobs** until `jobs` is defined; then shows the filtered count (e.g. `1 job` / `2 jobs`).
- **Single source for status strings:** `jobStatusLabels.ts` — `JOB_STATUS_LABEL`, tuple `JOB_STATUS_FILTER_ORDER`, and `filteredEmptyHeadline` derived from labels; `JobsListView` tabs built from the same data.
- **JobList:** Error state checked before loading (documented: stale TanStack error during refetch); `undefined` data treated as loading; defensive message + `role="alert"` if an impossible filter invariant is hit.
- **Tests:** `JobList`, `JobsListView`, `jobStatusLabels`, `filterJobsByTab`.

## Test plan
- `cd manu-gen/frontend && yarn vitest run src/features/jobs/components/JobList.test.tsx src/features/jobs/components/JobsListView.test.tsx src/features/jobs/components/jobStatusLabels.test.ts src/features/jobs/components/jobListFilters.test.ts`
- `yarn tsc --noEmit`
- Manually: open Jobs with slow network — toolbar should not flash `0 jobs`; switch tabs with data that excludes the current filter — empty state and headline behave as expected.

## Notes
- Headline template `No {Label} jobs` (e.g. "No In Progress jobs") is intentional to stay aligned with tab labels; copy can be refined later for tone.

Made with [Cursor](https://cursor.com)