### PR TITLE
feat(stations): slot capacity, Docker bind, and station UX

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "3000:3000"
     environment:
       PORT: 3000
+      HOST: 0.0.0.0
       DB_PATH: /data/manu-gen.db
       CORS_ORIGIN: http://localhost:5173
     volumes:

--- a/manu-gen/backend/src/db.ts
+++ b/manu-gen/backend/src/db.ts
@@ -94,13 +94,18 @@ db.transaction(() => {
   }
 })();
 
-const stationColumnNames = db
-  .prepare(`PRAGMA table_info(stations)`)
-  .all() as { name: string }[];
-if (!stationColumnNames.some((c) => c.name === "slot_capacity")) {
-  db.exec(
-    `ALTER TABLE stations ADD COLUMN slot_capacity INTEGER NOT NULL DEFAULT 1 CHECK (slot_capacity >= 1 AND slot_capacity <= 15)`,
-  );
+try {
+  const stationColumnNames = db
+    .prepare(`PRAGMA table_info(stations)`)
+    .all() as { name: string }[];
+  if (!stationColumnNames.some((c) => c.name === "slot_capacity")) {
+    db.exec(
+      `ALTER TABLE stations ADD COLUMN slot_capacity INTEGER NOT NULL DEFAULT 1 CHECK (slot_capacity >= 1 AND slot_capacity <= 15)`,
+    );
+  }
+} catch (err) {
+  const detail = err instanceof Error ? err.message : String(err);
+  throw new Error(`stations table migration (slot_capacity) failed: ${detail}`, { cause: err });
 }
 
 export default db;

--- a/manu-gen/backend/src/db.ts
+++ b/manu-gen/backend/src/db.ts
@@ -10,10 +10,11 @@ db.pragma("foreign_keys = ON");
 
 const SCHEMA: string[] = [
   `CREATE TABLE IF NOT EXISTS stations (
-    id       TEXT PRIMARY KEY,
-    name     TEXT NOT NULL,
-    location TEXT NOT NULL DEFAULT '',
-    eye_id   TEXT UNIQUE
+    id             TEXT PRIMARY KEY,
+    name           TEXT NOT NULL,
+    location       TEXT NOT NULL DEFAULT '',
+    eye_id         TEXT UNIQUE,
+    slot_capacity  INTEGER NOT NULL DEFAULT 1 CHECK (slot_capacity >= 1 AND slot_capacity <= 15)
   )`,
 
   `CREATE TABLE IF NOT EXISTS tracking_events (
@@ -92,5 +93,14 @@ db.transaction(() => {
     db.prepare(sql).run();
   }
 })();
+
+const stationColumnNames = db
+  .prepare(`PRAGMA table_info(stations)`)
+  .all() as { name: string }[];
+if (!stationColumnNames.some((c) => c.name === "slot_capacity")) {
+  db.exec(
+    `ALTER TABLE stations ADD COLUMN slot_capacity INTEGER NOT NULL DEFAULT 1 CHECK (slot_capacity >= 1 AND slot_capacity <= 15)`,
+  );
+}
 
 export default db;

--- a/manu-gen/backend/src/features/stations/stations.controller.test.ts
+++ b/manu-gen/backend/src/features/stations/stations.controller.test.ts
@@ -57,6 +57,14 @@ describe("POST /stations", () => {
     expect(tooHigh.status).toBe(400);
   });
 
+  it("should return 400 when slotCapacity is not coercible to a valid integer", async () => {
+    const notANumber = await request(app).post("/stations").send({ name: "A", slotCapacity: "nope" });
+    expect(notANumber.status).toBe(400);
+
+    const nullCap = await request(app).post("/stations").send({ name: "B", slotCapacity: null });
+    expect(nullCap.status).toBe(400);
+  });
+
   it("should return 400 when name is missing", async () => {
     const res = await request(app).post("/stations").send({});
 

--- a/manu-gen/backend/src/features/stations/stations.controller.test.ts
+++ b/manu-gen/backend/src/features/stations/stations.controller.test.ts
@@ -140,6 +140,17 @@ describe("PUT /stations/:id", () => {
     expect(res.body.slotCapacity).toBe(5);
   });
 
+  it("should return 400 when slotCapacity is out of range on update", async () => {
+    const createRes = await request(app).post("/stations").send({ name: "SlotTest", slotCapacity: 4 });
+    const id = createRes.body.id;
+
+    const tooLow = await request(app).put(`/stations/${id}`).send({ name: "SlotTest", slotCapacity: 0 });
+    expect(tooLow.status).toBe(400);
+
+    const tooHigh = await request(app).put(`/stations/${id}`).send({ name: "SlotTest", slotCapacity: 20 });
+    expect(tooHigh.status).toBe(400);
+  });
+
   it("should default location to empty string when omitted", async () => {
     const createRes = await request(app).post("/stations").send({ name: "Moulding", location: "X" });
     const id = createRes.body.id;

--- a/manu-gen/backend/src/features/stations/stations.controller.test.ts
+++ b/manu-gen/backend/src/features/stations/stations.controller.test.ts
@@ -27,6 +27,7 @@ describe("POST /stations", () => {
     expect(res.body.name).toBe("Polishing");
     expect(res.body.location).toBe("Floor 2");
     expect(res.body.eyeId).toBeNull();
+    expect(res.body.slotCapacity).toBe(1);
   });
 
   it("should default location to empty string", async () => {
@@ -34,6 +35,26 @@ describe("POST /stations", () => {
 
     expect(res.status).toBe(201);
     expect(res.body.location).toBe("");
+    expect(res.body.slotCapacity).toBe(1);
+  });
+
+  it("should persist slotCapacity when provided", async () => {
+    const res = await request(app).post("/stations").send({
+      name: "Finishing",
+      location: "Line A",
+      slotCapacity: 12,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.slotCapacity).toBe(12);
+  });
+
+  it("should return 400 when slotCapacity is out of range", async () => {
+    const tooLow = await request(app).post("/stations").send({ name: "A", slotCapacity: 0 });
+    expect(tooLow.status).toBe(400);
+
+    const tooHigh = await request(app).post("/stations").send({ name: "B", slotCapacity: 16 });
+    expect(tooHigh.status).toBe(400);
   });
 
   it("should return 400 when name is missing", async () => {
@@ -85,6 +106,38 @@ describe("PUT /stations/:id", () => {
     expect(res.body.id).toBe(id);
     expect(res.body.name).toBe("Glazing Updated");
     expect(res.body.location).toBe("B");
+    expect(res.body.slotCapacity).toBe(1);
+  });
+
+  it("should update slotCapacity", async () => {
+    const createRes = await request(app).post("/stations").send({
+      name: "Press",
+      location: "North",
+      slotCapacity: 3,
+    });
+    const id = createRes.body.id;
+
+    const res = await request(app).put(`/stations/${id}`).send({
+      name: "Press",
+      location: "North",
+      slotCapacity: 8,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.slotCapacity).toBe(8);
+  });
+
+  it("should preserve slotCapacity when omitted on update", async () => {
+    const createRes = await request(app).post("/stations").send({
+      name: "Cure",
+      slotCapacity: 5,
+    });
+    const id = createRes.body.id;
+
+    const res = await request(app).put(`/stations/${id}`).send({ name: "Cure Renamed" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.slotCapacity).toBe(5);
   });
 
   it("should default location to empty string when omitted", async () => {

--- a/manu-gen/backend/src/features/stations/stations.schema.ts
+++ b/manu-gen/backend/src/features/stations/stations.schema.ts
@@ -1,11 +1,14 @@
 import { z } from "zod";
 
+const slotCapacitySchema = z.coerce.number().int().min(1).max(15);
+
 export const createStationSchema = z.object({
   name: z.string().min(1, "name is required"),
   location: z.string().optional().default(""),
+  slotCapacity: slotCapacitySchema.optional(),
 });
 
-export type CreateStationInput = z.input<typeof createStationSchema>;
+export type CreateStationInput = z.infer<typeof createStationSchema>;
 
 export const assignEyeSchema = z.object({
   eyeId: z.string().min(1, "eyeId is required"),
@@ -16,6 +19,7 @@ export type AssignEyeInput = z.infer<typeof assignEyeSchema>;
 export const updateStationSchema = z.object({
   name: z.string().min(1, "name is required"),
   location: z.string().optional().default(""),
+  slotCapacity: slotCapacitySchema.optional(),
 });
 
 export type UpdateStationInput = z.infer<typeof updateStationSchema>;
@@ -25,6 +29,7 @@ export interface StationRow {
   name: string;
   location: string;
   eye_id: string | null;
+  slot_capacity: number;
 }
 
 export interface Station {
@@ -32,6 +37,7 @@ export interface Station {
   name: string;
   location: string;
   eyeId: string | null;
+  slotCapacity: number;
 }
 
 export function toStation(row: StationRow): Station {
@@ -40,5 +46,6 @@ export function toStation(row: StationRow): Station {
     name: row.name,
     location: row.location,
     eyeId: row.eye_id,
+    slotCapacity: row.slot_capacity,
   };
 }

--- a/manu-gen/backend/src/features/stations/stations.schema.ts
+++ b/manu-gen/backend/src/features/stations/stations.schema.ts
@@ -8,7 +8,8 @@ export const createStationSchema = z.object({
   slotCapacity: slotCapacitySchema.optional(),
 });
 
-export type CreateStationInput = z.infer<typeof createStationSchema>;
+/** Pre-parse shape: callers may omit fields that Zod defaults (e.g. tests, service without controller). */
+export type CreateStationInput = z.input<typeof createStationSchema>;
 
 export const assignEyeSchema = z.object({
   eyeId: z.string().min(1, "eyeId is required"),
@@ -22,7 +23,7 @@ export const updateStationSchema = z.object({
   slotCapacity: slotCapacitySchema.optional(),
 });
 
-export type UpdateStationInput = z.infer<typeof updateStationSchema>;
+export type UpdateStationInput = z.input<typeof updateStationSchema>;
 
 export interface StationRow {
   id: string;

--- a/manu-gen/backend/src/features/stations/stations.service.test.ts
+++ b/manu-gen/backend/src/features/stations/stations.service.test.ts
@@ -22,12 +22,43 @@ describe("createStation", () => {
     expect(station.name).toBe("Polishing");
     expect(station.location).toBe("Floor 2");
     expect(station.eyeId).toBeNull();
+    expect(station.slotCapacity).toBe(1);
   });
 
   it("should default location to empty string", () => {
     const station = stationsService.createStation({ name: "Casting" });
 
     expect(station.location).toBe("");
+    expect(station.slotCapacity).toBe(1);
+  });
+
+  it("should persist slotCapacity", () => {
+    const station = stationsService.createStation({ name: "Line 2", slotCapacity: 15 });
+
+    expect(station.slotCapacity).toBe(15);
+  });
+});
+
+describe("updateStation", () => {
+  it("should update slotCapacity", () => {
+    const created = stationsService.createStation({ name: "A", slotCapacity: 2 });
+    const updated = stationsService.updateStation(created.id, {
+      name: "A",
+      location: "",
+      slotCapacity: 10,
+    });
+
+    expect(updated.slotCapacity).toBe(10);
+  });
+
+  it("should preserve slotCapacity when not in input", () => {
+    const created = stationsService.createStation({ name: "B", slotCapacity: 7 });
+    const updated = stationsService.updateStation(created.id, {
+      name: "B Renamed",
+      location: "X",
+    });
+
+    expect(updated.slotCapacity).toBe(7);
   });
 });
 

--- a/manu-gen/backend/src/features/stations/stations.service.ts
+++ b/manu-gen/backend/src/features/stations/stations.service.ts
@@ -10,10 +10,10 @@ import type {
 } from "./stations.schema.js";
 import { toStation } from "./stations.schema.js";
 
-const STATION_COLUMNS = "id, name, location, eye_id";
+const STATION_COLUMNS = "id, name, location, eye_id, slot_capacity";
 
 const stmtInsert = db.prepare(
-  `INSERT INTO stations (id, name, location) VALUES (@id, @name, @location)`,
+  `INSERT INTO stations (id, name, location, slot_capacity) VALUES (@id, @name, @location, @slot_capacity)`,
 );
 
 const stmtGetById = db.prepare(`SELECT ${STATION_COLUMNS} FROM stations WHERE id = ?`);
@@ -33,7 +33,7 @@ const stmtAssignEye = db.prepare(`UPDATE stations SET eye_id = @eye_id WHERE id 
 const stmtDeleteStation = db.prepare(`DELETE FROM stations WHERE id = ?`);
 
 const stmtUpdateStation = db.prepare(
-  `UPDATE stations SET name = @name, location = @location WHERE id = @id`,
+  `UPDATE stations SET name = @name, location = @location, slot_capacity = @slot_capacity WHERE id = @id`,
 );
 
 function generateId(): string {
@@ -42,7 +42,13 @@ function generateId(): string {
 
 export function createStation(input: CreateStationInput): Station {
   const id = generateId();
-  stmtInsert.run({ id, name: input.name, location: input.location ?? "" });
+  const slotCapacity = input.slotCapacity ?? 1;
+  stmtInsert.run({
+    id,
+    name: input.name,
+    location: input.location ?? "",
+    slot_capacity: slotCapacity,
+  });
   return getStationById(id);
 }
 
@@ -69,10 +75,12 @@ export function updateStation(stationId: string, input: UpdateStationInput): Sta
   if (!row) {
     throw new AppError(404, `Station with id ${stationId} not found`);
   }
+  const slotCapacity = input.slotCapacity !== undefined ? input.slotCapacity : row.slot_capacity;
   stmtUpdateStation.run({
     id: stationId,
     name: input.name,
     location: input.location ?? "",
+    slot_capacity: slotCapacity,
   });
   return getStationById(stationId);
 }

--- a/manu-gen/backend/src/index.ts
+++ b/manu-gen/backend/src/index.ts
@@ -2,10 +2,12 @@ import { app } from "./app.js";
 import { logger } from "./shared/logger.js";
 import db from "./db.js";
 
-const PORT = process.env.PORT ?? 3000;
+const PORT = Number(process.env.PORT ?? 3000);
+// 0.0.0.0: required for Docker host port publish; loopback-only breaks host curl while healthchecks pass.
+const HOST = process.env.HOST ?? "0.0.0.0";
 
-const server = app.listen(PORT, () => {
-  logger.info("manu-gen backend started", { port: PORT });
+const server = app.listen(PORT, HOST, () => {
+  logger.info("manu-gen backend started", { host: HOST, port: PORT });
 });
 
 function shutdown() {

--- a/manu-gen/frontend/src/features/stations/components/EditStationView.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/EditStationView.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { createWrapper } from "../../../test-utils";
+import { EditStationView } from "./EditStationView";
+import type { Station } from "../stations.types";
+import { useUpdateStation } from "../hooks/useUpdateStation";
+import { useAssignEye } from "../hooks/useAssignEye";
+import { useUnassignEye } from "../hooks/useUnassignEye";
+import { usePipelines } from "../../pipelines/hooks/usePipelines";
+
+vi.mock("../hooks/useUpdateStation", () => ({ useUpdateStation: vi.fn() }));
+vi.mock("../hooks/useAssignEye", () => ({ useAssignEye: vi.fn() }));
+vi.mock("../hooks/useUnassignEye", () => ({ useUnassignEye: vi.fn() }));
+vi.mock("../../pipelines/hooks/usePipelines", () => ({ usePipelines: vi.fn() }));
+vi.mock("./StationEditDangerZone", () => ({
+  StationEditDangerZone: (): null => null,
+}));
+
+const station: Station = {
+  id: "station-edit1",
+  name: "Polishing",
+  location: "Floor 2",
+  eyeId: null,
+  slotCapacity: 3,
+};
+
+function mockDefaultHooks(): void {
+  vi.mocked(useUpdateStation).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(station),
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdateStation>);
+  vi.mocked(useAssignEye).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(station),
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useAssignEye>);
+  vi.mocked(useUnassignEye).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(station),
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useUnassignEye>);
+  vi.mocked(usePipelines).mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof usePipelines>);
+}
+
+describe("EditStationView", () => {
+  const onBack = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockDefaultHooks();
+  });
+
+  it("should re-enable Save after updateStation fails", async () => {
+    const updateAsync = vi.fn().mockRejectedValue(new Error("Network down"));
+    vi.mocked(useUpdateStation).mockReturnValue({
+      mutateAsync: updateAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateStation>);
+
+    const user = userEvent.setup();
+    render(<EditStationView station={station} onBack={onBack} />, { wrapper: createWrapper() });
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network down")).toBeInTheDocument();
+    });
+
+    const saveBtn = screen.getByRole("button", { name: "Save changes" });
+    expect(saveBtn).not.toBeDisabled();
+  });
+
+  it("should call updateStation and onBack when saving with no camera change", async () => {
+    const updateAsync = vi.fn().mockResolvedValue(station);
+    const assignAsync = vi.fn();
+    const unassignAsync = vi.fn();
+    vi.mocked(useUpdateStation).mockReturnValue({
+      mutateAsync: updateAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateStation>);
+    vi.mocked(useAssignEye).mockReturnValue({
+      mutateAsync: assignAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAssignEye>);
+    vi.mocked(useUnassignEye).mockReturnValue({
+      mutateAsync: unassignAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUnassignEye>);
+
+    const user = userEvent.setup();
+    render(<EditStationView station={station} onBack={onBack} />, { wrapper: createWrapper() });
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(onBack).toHaveBeenCalled();
+    });
+
+    expect(updateAsync).toHaveBeenCalledWith({
+      id: station.id,
+      name: station.name,
+      location: station.location,
+      slotCapacity: station.slotCapacity,
+    });
+    expect(assignAsync).not.toHaveBeenCalled();
+    expect(unassignAsync).not.toHaveBeenCalled();
+  });
+
+  it("should call assignEye after update when assigning a camera", async () => {
+    const updateAsync = vi.fn().mockResolvedValue(station);
+    const assignAsync = vi.fn().mockResolvedValue({ ...station, eyeId: "eye-7" });
+    vi.mocked(useUpdateStation).mockReturnValue({
+      mutateAsync: updateAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateStation>);
+    vi.mocked(useAssignEye).mockReturnValue({
+      mutateAsync: assignAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAssignEye>);
+
+    const user = userEvent.setup();
+    render(<EditStationView station={station} onBack={onBack} />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByPlaceholderText(/cam-01, eye-3/), "eye-7");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(onBack).toHaveBeenCalled();
+    });
+
+    expect(updateAsync).toHaveBeenCalled();
+    expect(assignAsync).toHaveBeenCalledWith({ stationId: station.id, eyeId: "eye-7" });
+  });
+
+  it("should call unassignEye after update when clearing the camera", async () => {
+    const withEye: Station = { ...station, eyeId: "eye-1" };
+    const updateAsync = vi.fn().mockResolvedValue(withEye);
+    const unassignAsync = vi.fn().mockResolvedValue({ ...withEye, eyeId: null });
+    vi.mocked(useUpdateStation).mockReturnValue({
+      mutateAsync: updateAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateStation>);
+    vi.mocked(useUnassignEye).mockReturnValue({
+      mutateAsync: unassignAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUnassignEye>);
+
+    const user = userEvent.setup();
+    render(<EditStationView station={withEye} onBack={onBack} />, { wrapper: createWrapper() });
+
+    await user.clear(screen.getByPlaceholderText(/cam-01, eye-3/));
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(onBack).toHaveBeenCalled();
+    });
+
+    expect(updateAsync).toHaveBeenCalled();
+    expect(unassignAsync).toHaveBeenCalledWith(station.id);
+  });
+
+  it("should call assignEye after update when swapping to a different eye", async () => {
+    const withEye: Station = { ...station, eyeId: "eye-1" };
+    const updateAsync = vi.fn().mockResolvedValue(withEye);
+    const assignAsync = vi.fn().mockResolvedValue({ ...withEye, eyeId: "eye-2" });
+    vi.mocked(useUpdateStation).mockReturnValue({
+      mutateAsync: updateAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateStation>);
+    vi.mocked(useAssignEye).mockReturnValue({
+      mutateAsync: assignAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAssignEye>);
+
+    const user = userEvent.setup();
+    render(<EditStationView station={withEye} onBack={onBack} />, { wrapper: createWrapper() });
+
+    const camera = screen.getByPlaceholderText(/cam-01, eye-3/);
+    await user.clear(camera);
+    await user.type(camera, "eye-2");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(onBack).toHaveBeenCalled();
+    });
+
+    expect(assignAsync).toHaveBeenCalledWith({ stationId: station.id, eyeId: "eye-2" });
+  });
+
+  it("should show recovery message and not navigate when assignEye fails after update succeeds", async () => {
+    const updateAsync = vi.fn().mockResolvedValue(station);
+    const assignAsync = vi.fn().mockRejectedValue(new Error("Eye already assigned elsewhere"));
+    vi.mocked(useUpdateStation).mockReturnValue({
+      mutateAsync: updateAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateStation>);
+    vi.mocked(useAssignEye).mockReturnValue({
+      mutateAsync: assignAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAssignEye>);
+
+    const user = userEvent.setup();
+    render(<EditStationView station={station} onBack={onBack} />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByPlaceholderText(/cam-01, eye-3/), "eye-9");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Eye already assigned elsewhere/)).toBeInTheDocument();
+      expect(screen.getByText(/Station details were saved/)).toBeInTheDocument();
+    });
+    expect(onBack).not.toHaveBeenCalled();
+  });
+});

--- a/manu-gen/frontend/src/features/stations/components/EditStationView.tsx
+++ b/manu-gen/frontend/src/features/stations/components/EditStationView.tsx
@@ -56,32 +56,34 @@ export function EditStationView({ station, onBack }: EditStationViewProps): Reac
     const newEye = (values.cameraId ?? "").trim();
 
     try {
-      await updateStation({
-        id: station.id,
-        name: values.name,
-        location: values.location ?? "",
-        slotCapacity: clampSlotCapacityForApi(values.slotCapacity),
-      });
-    } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : "Save failed");
-      return;
-    }
-
-    try {
-      if (oldEye !== newEye) {
-        if (oldEye && !newEye) {
-          await unassignEye(station.id);
-        } else if (newEye) {
-          await assignEye({ stationId: station.id, eyeId: newEye });
-        }
+      try {
+        await updateStation({
+          id: station.id,
+          name: values.name,
+          location: values.location ?? "",
+          slotCapacity: clampSlotCapacityForApi(values.slotCapacity),
+        });
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err.message : "Save failed");
+        return;
       }
 
-      onBack();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Save failed";
-      setSubmitError(
-        `${msg} Station details were saved. Return to the list and edit this station to fix the camera assignment.`,
-      );
+      try {
+        if (oldEye !== newEye) {
+          if (oldEye && !newEye) {
+            await unassignEye(station.id);
+          } else if (newEye) {
+            await assignEye({ stationId: station.id, eyeId: newEye });
+          }
+        }
+
+        onBack();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Save failed";
+        setSubmitError(
+          `${msg} Station details were saved. Return to the list and edit this station to fix the camera assignment.`,
+        );
+      }
     } finally {
       setIsSaving(false);
     }

--- a/manu-gen/frontend/src/features/stations/components/EditStationView.tsx
+++ b/manu-gen/frontend/src/features/stations/components/EditStationView.tsx
@@ -26,7 +26,7 @@ export function EditStationView({ station, onBack }: EditStationViewProps): Reac
     () => ({
       name: station.name,
       location: station.location,
-      slotCapacity: station.slotCapacity ?? 1,
+      slotCapacity: station.slotCapacity,
       cameraId: station.eyeId ?? "",
     }),
     [station],
@@ -59,6 +59,7 @@ export function EditStationView({ station, onBack }: EditStationViewProps): Reac
         id: station.id,
         name: values.name,
         location: values.location ?? "",
+        slotCapacity: values.slotCapacity,
       });
 
       if (oldEye !== newEye) {
@@ -88,7 +89,6 @@ export function EditStationView({ station, onBack }: EditStationViewProps): Reac
       onBack={onBack}
       onSubmit={handleSubmit}
       backLabel={station.name}
-      capacityPreview="utilized"
       pipelineRefs={pipelineRefs}
       dangerZone={<StationEditDangerZone station={station} onDeleted={onBack} />}
     />

--- a/manu-gen/frontend/src/features/stations/components/EditStationView.tsx
+++ b/manu-gen/frontend/src/features/stations/components/EditStationView.tsx
@@ -7,6 +7,7 @@ import { useUnassignEye } from "../hooks/useUnassignEye";
 import { usePipelines } from "../../pipelines/hooks/usePipelines";
 import type { Station } from "../stations.types";
 import type { CreateStationFormValues } from "../stations.schema";
+import { clampSlotCapacityForApi } from "../slotCapacity.utils";
 
 interface EditStationViewProps {
   station: Station;
@@ -59,9 +60,14 @@ export function EditStationView({ station, onBack }: EditStationViewProps): Reac
         id: station.id,
         name: values.name,
         location: values.location ?? "",
-        slotCapacity: values.slotCapacity,
+        slotCapacity: clampSlotCapacityForApi(values.slotCapacity),
       });
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Save failed");
+      return;
+    }
 
+    try {
       if (oldEye !== newEye) {
         if (oldEye && !newEye) {
           await unassignEye(station.id);
@@ -72,7 +78,10 @@ export function EditStationView({ station, onBack }: EditStationViewProps): Reac
 
       onBack();
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : "Save failed");
+      const msg = err instanceof Error ? err.message : "Save failed";
+      setSubmitError(
+        `${msg} Station details were saved. Return to the list and edit this station to fix the camera assignment.`,
+      );
     } finally {
       setIsSaving(false);
     }

--- a/manu-gen/frontend/src/features/stations/components/NewStationView.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/NewStationView.test.tsx
@@ -141,16 +141,58 @@ describe("NewStationView", () => {
     });
   });
 
-  it("should disable submit button while create is pending", () => {
+  it("should disable submit while save is in progress", async () => {
+    let resolveCreate!: (s: Station) => void;
+    const createPromise = new Promise<Station>((resolve) => {
+      resolveCreate = resolve;
+    });
+    const createAsync = vi.fn().mockReturnValue(createPromise);
     vi.mocked(useCreateStation).mockReturnValue({
-      mutateAsync: vi.fn(),
+      mutateAsync: createAsync,
       mutate: vi.fn(),
-      isPending: true,
+      isPending: false,
     } as unknown as ReturnType<typeof useCreateStation>);
 
+    const user = userEvent.setup();
     render(<NewStationView onBack={onBack} />, { wrapper: createWrapper() });
 
-    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    await user.type(screen.getByPlaceholderText(/Kiln A/), "Polishing");
+    const clickPromise = user.click(screen.getByRole("button", { name: "Create Station" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    });
+
+    resolveCreate(createdStation);
+    await clickPromise;
+  });
+
+  it("should show recovery message when assign fails after station is created", async () => {
+    const createAsync = vi.fn().mockResolvedValue(createdStation);
+    const assignAsync = vi.fn().mockRejectedValue(new Error("Eye already assigned"));
+    vi.mocked(useCreateStation).mockReturnValue({
+      mutateAsync: createAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateStation>);
+    vi.mocked(useAssignEye).mockReturnValue({
+      mutateAsync: assignAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAssignEye>);
+
+    const user = userEvent.setup();
+    render(<NewStationView onBack={onBack} />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByPlaceholderText(/Kiln A/), "Polishing");
+    await user.type(screen.getByPlaceholderText(/cam-01, eye-3/), "eye-1");
+    await user.click(screen.getByRole("button", { name: "Create Station" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Eye already assigned/)).toBeInTheDocument();
+      expect(screen.getByText(/The station was created/)).toBeInTheDocument();
+    });
+    expect(onBack).not.toHaveBeenCalled();
   });
 
   it("should navigate back on successful creation", async () => {

--- a/manu-gen/frontend/src/features/stations/components/NewStationView.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/NewStationView.test.tsx
@@ -3,27 +3,43 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import { createWrapper } from "../../../test-utils";
 import { NewStationView } from "./NewStationView";
-
-vi.mock("../hooks/useCreateStation", () => ({
-  useCreateStation: vi.fn(),
-}));
-
+import type { Station } from "../stations.types";
 import { useCreateStation } from "../hooks/useCreateStation";
+import { useAssignEye } from "../hooks/useAssignEye";
+
+vi.mock("../hooks/useCreateStation", () => ({ useCreateStation: vi.fn() }));
+vi.mock("../hooks/useAssignEye", () => ({ useAssignEye: vi.fn() }));
+
+const createdStation: Station = {
+  id: "station-new1",
+  name: "Polishing",
+  location: "Floor 2",
+  eyeId: null,
+  slotCapacity: 1,
+};
+
+function mockDefaultHooks(): void {
+  vi.mocked(useCreateStation).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(createdStation),
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useCreateStation>);
+  vi.mocked(useAssignEye).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(createdStation),
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useAssignEye>);
+}
 
 describe("NewStationView", () => {
   const onBack = vi.fn();
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockDefaultHooks();
   });
 
   it("should render form fields and preview", () => {
-    vi.mocked(useCreateStation).mockReturnValue({
-      mutate: vi.fn(),
-      isPending: false,
-      error: null,
-    } as unknown as ReturnType<typeof useCreateStation>);
-
     render(<NewStationView onBack={onBack} />, { wrapper: createWrapper() });
 
     expect(screen.getByRole("heading", { level: 1, name: "New Station" })).toBeInTheDocument();
@@ -34,12 +50,6 @@ describe("NewStationView", () => {
   });
 
   it("should call onBack when back button is clicked", async () => {
-    vi.mocked(useCreateStation).mockReturnValue({
-      mutate: vi.fn(),
-      isPending: false,
-      error: null,
-    } as unknown as ReturnType<typeof useCreateStation>);
-
     const user = userEvent.setup();
     render(<NewStationView onBack={onBack} />, { wrapper: createWrapper() });
 
@@ -49,30 +59,22 @@ describe("NewStationView", () => {
   });
 
   it("should show validation error when name is empty", async () => {
-    vi.mocked(useCreateStation).mockReturnValue({
-      mutate: vi.fn(),
-      isPending: false,
-      error: null,
-    } as unknown as ReturnType<typeof useCreateStation>);
-
     const user = userEvent.setup();
     render(<NewStationView onBack={onBack} />, { wrapper: createWrapper() });
 
     await user.click(screen.getByRole("button", { name: "Create Station" }));
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Station name is required"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Station name is required")).toBeInTheDocument();
     });
   });
 
-  it("should call mutate with form values on valid submit", async () => {
-    const mutate = vi.fn();
+  it("should call createStation with form values on valid submit", async () => {
+    const createAsync = vi.fn().mockResolvedValue(createdStation);
     vi.mocked(useCreateStation).mockReturnValue({
-      mutate,
+      mutateAsync: createAsync,
+      mutate: vi.fn(),
       isPending: false,
-      error: null,
     } as unknown as ReturnType<typeof useCreateStation>);
 
     const user = userEvent.setup();
@@ -83,30 +85,67 @@ describe("NewStationView", () => {
     await user.click(screen.getByRole("button", { name: "Create Station" }));
 
     await waitFor(() => {
-      expect(mutate).toHaveBeenCalledWith(
-        expect.objectContaining({ name: "Polishing", location: "Floor 2" }),
-        expect.any(Object),
+      expect(createAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Polishing",
+          location: "Floor 2",
+          slotCapacity: 1,
+          cameraId: "",
+        }),
       );
     });
   });
 
-  it("should display server error", () => {
+  it("should call assignEye after create when camera ID is set", async () => {
+    const createAsync = vi.fn().mockResolvedValue(createdStation);
+    const assignAsync = vi.fn().mockResolvedValue({ ...createdStation, eyeId: "eye-9" });
     vi.mocked(useCreateStation).mockReturnValue({
+      mutateAsync: createAsync,
       mutate: vi.fn(),
       isPending: false,
-      error: new Error("Duplicate name"),
     } as unknown as ReturnType<typeof useCreateStation>);
+    vi.mocked(useAssignEye).mockReturnValue({
+      mutateAsync: assignAsync,
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useAssignEye>);
 
+    const user = userEvent.setup();
     render(<NewStationView onBack={onBack} />, { wrapper: createWrapper() });
 
-    expect(screen.getByText("Duplicate name")).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText(/Kiln A/), "Polishing");
+    await user.type(screen.getByPlaceholderText(/cam-01, eye-3/), "eye-9");
+    await user.click(screen.getByRole("button", { name: "Create Station" }));
+
+    await waitFor(() => {
+      expect(createAsync).toHaveBeenCalled();
+      expect(assignAsync).toHaveBeenCalledWith({ stationId: createdStation.id, eyeId: "eye-9" });
+    });
   });
 
-  it("should disable submit button while pending", () => {
+  it("should display submit error when create fails", async () => {
     vi.mocked(useCreateStation).mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(new Error("Duplicate name")),
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useCreateStation>);
+
+    const user = userEvent.setup();
+    render(<NewStationView onBack={onBack} />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByPlaceholderText(/Kiln A/), "Polishing");
+    await user.click(screen.getByRole("button", { name: "Create Station" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Duplicate name")).toBeInTheDocument();
+    });
+  });
+
+  it("should disable submit button while create is pending", () => {
+    vi.mocked(useCreateStation).mockReturnValue({
+      mutateAsync: vi.fn(),
       mutate: vi.fn(),
       isPending: true,
-      error: null,
     } as unknown as ReturnType<typeof useCreateStation>);
 
     render(<NewStationView onBack={onBack} />, { wrapper: createWrapper() });
@@ -115,13 +154,11 @@ describe("NewStationView", () => {
   });
 
   it("should navigate back on successful creation", async () => {
-    const mutate = vi.fn().mockImplementation((_values, options) => {
-      options.onSuccess();
-    });
+    const createAsync = vi.fn().mockResolvedValue(createdStation);
     vi.mocked(useCreateStation).mockReturnValue({
-      mutate,
+      mutateAsync: createAsync,
+      mutate: vi.fn(),
       isPending: false,
-      error: null,
     } as unknown as ReturnType<typeof useCreateStation>);
 
     const user = userEvent.setup();

--- a/manu-gen/frontend/src/features/stations/components/NewStationView.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/NewStationView.test.tsx
@@ -85,14 +85,11 @@ describe("NewStationView", () => {
     await user.click(screen.getByRole("button", { name: "Create Station" }));
 
     await waitFor(() => {
-      expect(createAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: "Polishing",
-          location: "Floor 2",
-          slotCapacity: 1,
-          cameraId: "",
-        }),
-      );
+      expect(createAsync).toHaveBeenCalledWith({
+        name: "Polishing",
+        location: "Floor 2",
+        slotCapacity: 1,
+      });
     });
   });
 

--- a/manu-gen/frontend/src/features/stations/components/NewStationView.tsx
+++ b/manu-gen/frontend/src/features/stations/components/NewStationView.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { StationForm } from "./StationForm";
 import { useCreateStation } from "../hooks/useCreateStation";
 import { useAssignEye } from "../hooks/useAssignEye";
-import type { CreateStationFormValues } from "../stations.schema";
+import type { CreateStationFormValues, CreateStationRequestBody } from "../stations.schema";
 import { clampSlotCapacityForApi } from "../slotCapacity.utils";
 
 interface NewStationViewProps {
@@ -19,13 +19,14 @@ export function NewStationView({ onBack }: NewStationViewProps): React.JSX.Eleme
     setSubmitError(null);
     setIsSaving(true);
     const camera = (values.cameraId ?? "").trim();
-    const payload: CreateStationFormValues = {
-      ...values,
+    const createBody: CreateStationRequestBody = {
+      name: values.name,
+      location: values.location,
       slotCapacity: clampSlotCapacityForApi(values.slotCapacity),
     };
     let createdId: string | null = null;
     try {
-      const created = await createStation(payload);
+      const created = await createStation(createBody);
       createdId = created.id;
       if (camera) {
         await assignEye({ stationId: created.id, eyeId: camera });

--- a/manu-gen/frontend/src/features/stations/components/NewStationView.tsx
+++ b/manu-gen/frontend/src/features/stations/components/NewStationView.tsx
@@ -1,22 +1,43 @@
+import { useState } from "react";
 import { StationForm } from "./StationForm";
 import { useCreateStation } from "../hooks/useCreateStation";
+import { useAssignEye } from "../hooks/useAssignEye";
+import type { CreateStationFormValues } from "../stations.schema";
 
 interface NewStationViewProps {
   onBack: () => void;
 }
 
 export function NewStationView({ onBack }: NewStationViewProps): React.JSX.Element {
-  const { mutate, isPending, error } = useCreateStation();
+  const { mutateAsync: createStation, isPending: isCreating } = useCreateStation();
+  const { mutateAsync: assignEye, isPending: isAssigning } = useAssignEye();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const isSubmitting = isCreating || isAssigning;
+
+  async function handleSubmit(values: CreateStationFormValues): Promise<void> {
+    setSubmitError(null);
+    try {
+      const created = await createStation(values);
+      const camera = (values.cameraId ?? "").trim();
+      if (camera) {
+        await assignEye({ stationId: created.id, eyeId: camera });
+      }
+      onBack();
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Save failed");
+    }
+  }
 
   return (
     <StationForm
       title="New Station"
       submitLabel="Create Station"
       defaultValues={{ name: "", location: "", slotCapacity: 1, cameraId: "" }}
-      isSubmitting={isPending}
-      errorMessage={error?.message ?? null}
+      isSubmitting={isSubmitting}
+      errorMessage={submitError}
       onBack={onBack}
-      onSubmit={(values) => mutate(values, { onSuccess: onBack })}
+      onSubmit={handleSubmit}
     />
   );
 }

--- a/manu-gen/frontend/src/features/stations/components/NewStationView.tsx
+++ b/manu-gen/frontend/src/features/stations/components/NewStationView.tsx
@@ -3,29 +3,45 @@ import { StationForm } from "./StationForm";
 import { useCreateStation } from "../hooks/useCreateStation";
 import { useAssignEye } from "../hooks/useAssignEye";
 import type { CreateStationFormValues } from "../stations.schema";
+import { clampSlotCapacityForApi } from "../slotCapacity.utils";
 
 interface NewStationViewProps {
   onBack: () => void;
 }
 
 export function NewStationView({ onBack }: NewStationViewProps): React.JSX.Element {
-  const { mutateAsync: createStation, isPending: isCreating } = useCreateStation();
-  const { mutateAsync: assignEye, isPending: isAssigning } = useAssignEye();
+  const { mutateAsync: createStation } = useCreateStation();
+  const { mutateAsync: assignEye } = useAssignEye();
   const [submitError, setSubmitError] = useState<string | null>(null);
-
-  const isSubmitting = isCreating || isAssigning;
+  const [isSaving, setIsSaving] = useState(false);
 
   async function handleSubmit(values: CreateStationFormValues): Promise<void> {
     setSubmitError(null);
+    setIsSaving(true);
+    const camera = (values.cameraId ?? "").trim();
+    const payload: CreateStationFormValues = {
+      ...values,
+      slotCapacity: clampSlotCapacityForApi(values.slotCapacity),
+    };
+    let createdId: string | null = null;
     try {
-      const created = await createStation(values);
-      const camera = (values.cameraId ?? "").trim();
+      const created = await createStation(payload);
+      createdId = created.id;
       if (camera) {
         await assignEye({ stationId: created.id, eyeId: camera });
       }
       onBack();
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : "Save failed");
+      const msg = err instanceof Error ? err.message : "Save failed";
+      if (createdId !== null && camera) {
+        setSubmitError(
+          `${msg} The station was created. Open it from the list to assign the camera, or try again.`,
+        );
+      } else {
+        setSubmitError(msg);
+      }
+    } finally {
+      setIsSaving(false);
     }
   }
 
@@ -34,7 +50,7 @@ export function NewStationView({ onBack }: NewStationViewProps): React.JSX.Eleme
       title="New Station"
       submitLabel="Create Station"
       defaultValues={{ name: "", location: "", slotCapacity: 1, cameraId: "" }}
-      isSubmitting={isSubmitting}
+      isSubmitting={isSaving}
       errorMessage={submitError}
       onBack={onBack}
       onSubmit={handleSubmit}

--- a/manu-gen/frontend/src/features/stations/components/StationForm.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationForm.tsx
@@ -55,7 +55,6 @@ function StationPreview({
   location,
   slotCapacity,
   cameraId,
-  capacityPreview,
   pipelineRefs,
   showPipelinesBlock,
 }: {
@@ -63,19 +62,12 @@ function StationPreview({
   location: string;
   slotCapacity: number;
   cameraId: string;
-  capacityPreview: "uniform" | "utilized";
   pipelineRefs: StationPipelineRef[] | undefined;
   showPipelinesBlock: boolean;
 }): React.JSX.Element {
   const displayName = name || "New Station";
   const displayLocation = location || "Location not set";
   const slots = clampSlots(Number.isFinite(slotCapacity) ? slotCapacity : 1);
-  const occupiedForCard =
-    capacityPreview === "utilized"
-      ? Math.min(slots, Math.max(0, Math.round(slots * 0.6)))
-      : slots;
-  const occupiedDash = Math.min(slots, Math.max(0, Math.round(slots * 0.55)));
-  const queueCount = Math.max(0, slots - occupiedDash);
 
   return (
     <div className={prim.previewShell}>
@@ -105,62 +97,16 @@ function StationPreview({
               <span className={styles.previewCapacityLabel}>Capacity</span>
               <div className={styles.previewCapacityValue}>
                 <div className={styles.previewSlotDots}>
-                  {capacityPreview === "uniform"
-                    ? Array.from({ length: slots }).map((_, i) => (
-                        <div key={i} className={styles.previewSlotDot} />
-                      ))
-                    : Array.from({ length: slots }).map((_, i) => (
-                        <div
-                          key={i}
-                          className={
-                            i < occupiedForCard
-                              ? `${styles.previewSlotDot} ${styles.previewSlotDotFilled}`
-                              : `${styles.previewSlotDot} ${styles.previewSlotDotEmpty}`
-                          }
-                        />
-                      ))}
+                  {Array.from({ length: slots }).map((_, i) => (
+                    <div key={i} className={styles.previewSlotDot} />
+                  ))}
                 </div>
                 <span className={styles.previewSlotLabel}>
                   {slots} {slots === 1 ? "slot" : "slots"}
-                  {slotCapacity === 0 && capacityPreview === "uniform" && " (default)"}
+                  {slotCapacity === 0 && " (default)"}
                 </span>
               </div>
             </div>
-          </div>
-        </div>
-
-        <div>
-          <div className={styles.previewSectionLabel}>Live dashboard — utilization view</div>
-          <div className={styles.previewDashCard}>
-            <div className={styles.previewDashTitleRow}>
-              <span className={styles.previewDashName}>{displayName}</span>
-            </div>
-            <div className={styles.previewDashSlotsRow}>
-              <div className={styles.previewDashSlotTrack}>
-                <div className={styles.previewDashSlotDots}>
-                  {Array.from({ length: slots }).map((_, i) => (
-                    <div
-                      key={i}
-                      className={
-                        i < occupiedDash
-                          ? styles.previewDashSlot
-                          : `${styles.previewDashSlot} ${styles.previewDashSlotIdle}`
-                      }
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-            <div className={styles.previewDashMetricsEndRow}>
-              <span className={styles.previewDashRatio}>
-                {occupiedDash}/{slots} slots
-              </span>
-              <span className={styles.previewDashQueue}>Queue: {queueCount}</span>
-            </div>
-            <p className={styles.previewDashFootnote}>
-              Slot squares on the dashboard show real-time occupancy once the camera starts scanning
-              trays in and out.
-            </p>
           </div>
         </div>
 
@@ -204,8 +150,6 @@ export interface StationFormProps {
   onSubmit: (values: CreateStationFormValues) => void;
   /** Back control label — design: station name on edit, &quot;Stations&quot; on create */
   backLabel?: string;
-  /** Station card capacity dots: uniform (new) or simulated utilization (edit) */
-  capacityPreview?: "uniform" | "utilized";
   /** When set, shows the &quot;Used in pipelines&quot; block (edit). */
   pipelineRefs?: StationPipelineRef[];
   /** Left column content below fields (e.g. danger zone on edit) */
@@ -221,7 +165,6 @@ export function StationForm({
   onBack,
   onSubmit,
   backLabel = "Stations",
-  capacityPreview = "uniform",
   pipelineRefs,
   dangerZone,
 }: StationFormProps): React.JSX.Element {
@@ -315,7 +258,6 @@ export function StationForm({
           location={watchedLocation}
           slotCapacity={watchedSlotCapacity}
           cameraId={watchedCameraId}
-          capacityPreview={capacityPreview}
           pipelineRefs={pipelineRefs}
           showPipelinesBlock={showPipelinesBlock}
         />

--- a/manu-gen/frontend/src/features/stations/components/StationForm.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationForm.tsx
@@ -103,7 +103,6 @@ function StationPreview({
                 </div>
                 <span className={styles.previewSlotLabel}>
                   {slots} {slots === 1 ? "slot" : "slots"}
-                  {slotCapacity === 0 && " (default)"}
                 </span>
               </div>
             </div>

--- a/manu-gen/frontend/src/features/stations/components/StationList.module.css
+++ b/manu-gen/frontend/src/features/stations/components/StationList.module.css
@@ -80,3 +80,57 @@
   font-size: var(--text-sm);
   color: var(--text-muted);
 }
+
+/* Inline alert: same dismiss pattern as HintBanner (X), palette uses --alert (signal) per design tokens */
+.deleteAlert {
+  position: relative;
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--alert) 28%, var(--border));
+  background: var(--alert-light);
+  /* Equal vertical padding; extra horizontal end space for the absolute close control */
+  padding: var(--space-3) calc(var(--space-4) + var(--space-6)) var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.deleteAlertMessage {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  color: var(--alert-dark);
+}
+
+.deleteAlertClose {
+  position: absolute;
+  top: 50%;
+  right: var(--space-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--space-6);
+  height: var(--space-6);
+  margin-top: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  padding: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  transform: translateY(-50%);
+  transition: color var(--duration-fast) var(--easing-default),
+    background-color var(--duration-fast) var(--easing-default);
+}
+
+.deleteAlertClose:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+
+.deleteAlertClose:focus-visible {
+  outline: 2px solid var(--alert);
+  outline-offset: 2px;
+}

--- a/manu-gen/frontend/src/features/stations/components/StationList.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationList.test.tsx
@@ -16,8 +16,8 @@ vi.mock("../hooks/useDeleteStation", () => ({
 import { useStations } from "../hooks/useStations";
 
 const sampleStations: Station[] = [
-  { id: "station-aaa", name: "Polishing", location: "Floor 2", eyeId: "eye-1" },
-  { id: "station-bbb", name: "Casting", location: "", eyeId: null },
+  { id: "station-aaa", name: "Polishing", location: "Floor 2", eyeId: "eye-1", slotCapacity: 1 },
+  { id: "station-bbb", name: "Casting", location: "", eyeId: null, slotCapacity: 1 },
 ];
 
 describe("StationList", () => {

--- a/manu-gen/frontend/src/features/stations/components/StationList.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationList.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import { createWrapper } from "../../../test-utils";
 import { StationList } from "./StationList";
@@ -14,6 +15,7 @@ vi.mock("../hooks/useDeleteStation", () => ({
 }));
 
 import { useStations } from "../hooks/useStations";
+import { useDeleteStation } from "../hooks/useDeleteStation";
 
 const sampleStations: Station[] = [
   { id: "station-aaa", name: "Polishing", location: "Floor 2", eyeId: "eye-1", slotCapacity: 1 },
@@ -99,5 +101,39 @@ describe("StationList", () => {
     expect(screen.getByText("Slot capacity")).toBeInTheDocument();
     expect(screen.getByText("Camera")).toBeInTheDocument();
     expect(screen.getByText("Actions")).toBeInTheDocument();
+  });
+
+  it("should show delete failure in a top alert with Dismiss, not in the table row", async () => {
+    const mutate = vi.fn().mockImplementation((_id, options) => {
+      options.onError(new Error("Cannot delete station: used in pipeline step(s)"));
+    });
+    vi.mocked(useDeleteStation).mockReturnValue({
+      mutate,
+      isPending: false,
+      error: null,
+    } as unknown as ReturnType<typeof useDeleteStation>);
+
+    vi.mocked(useStations).mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: [sampleStations[0]],
+    } as unknown as ReturnType<typeof useStations>);
+
+    const user = userEvent.setup();
+    render(<StationList />, { wrapper: createWrapper() });
+
+    await user.click(screen.getByRole("button", { name: "Delete station Polishing" }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Cannot delete station: used in pipeline step(s)");
+
+    expect(screen.getByRole("button", { name: "Delete station Polishing" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Dismiss notification" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
   });
 });

--- a/manu-gen/frontend/src/features/stations/components/StationList.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationList.tsx
@@ -1,4 +1,5 @@
-import { PackageOpen } from "lucide-react";
+import { useState } from "react";
+import { PackageOpen, X } from "lucide-react";
 import { useStations } from "../hooks/useStations";
 import { ListCard } from "../../../shared/components/ListCard";
 import { StationTable } from "./StationTable";
@@ -44,6 +45,7 @@ interface StationListProps {
 
 export function StationList({ onSelectStation }: StationListProps): React.JSX.Element {
   const { data, isLoading, error } = useStations();
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   if (isLoading) {
     return <LoadingSkeleton />;
@@ -73,12 +75,33 @@ export function StationList({ onSelectStation }: StationListProps): React.JSX.El
   }
 
   return (
-    <ListCard
-      title="All Stations"
-      count={stations.length}
-      countLabel={stations.length === 1 ? "station" : "stations"}
-    >
-      <StationTable stations={stations} onSelectStation={onSelectStation} />
-    </ListCard>
+    <>
+      {deleteError !== null && deleteError !== "" && (
+        <div className={styles.deleteAlert} role="alert">
+          <p className={styles.deleteAlertMessage}>{deleteError}</p>
+          <button
+            type="button"
+            className={styles.deleteAlertClose}
+            aria-label="Dismiss notification"
+            onClick={() => {
+              setDeleteError(null);
+            }}
+          >
+            <X size={12} strokeWidth={1.5} aria-hidden />
+          </button>
+        </div>
+      )}
+      <ListCard
+        title="All Stations"
+        count={stations.length}
+        countLabel={stations.length === 1 ? "station" : "stations"}
+      >
+        <StationTable
+          stations={stations}
+          onDeleteError={setDeleteError}
+          onSelectStation={onSelectStation}
+        />
+      </ListCard>
+    </>
   );
 }

--- a/manu-gen/frontend/src/features/stations/components/StationTable.module.css
+++ b/manu-gen/frontend/src/features/stations/components/StationTable.module.css
@@ -105,15 +105,6 @@
   color: var(--text);
 }
 
-.errorTruncate {
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: var(--text-xs);
-  color: var(--status-late);
-}
-
 .stationName {
   font-size: var(--text-base);
   font-weight: var(--weight-semibold);

--- a/manu-gen/frontend/src/features/stations/components/StationTable.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationTable.test.tsx
@@ -11,7 +11,7 @@ import { useDeleteStation } from "../hooks/useDeleteStation";
 
 const stations: Station[] = [
   { id: "station-aaa", name: "Polishing", location: "Floor 2", eyeId: "eye-1", slotCapacity: 3 },
-  { id: "station-bbb", name: "Casting", location: "", eyeId: null },
+  { id: "station-bbb", name: "Casting", location: "", eyeId: null, slotCapacity: 1 },
 ];
 
 function mockDeleteHook(overrides?: Partial<ReturnType<typeof useDeleteStation>>) {

--- a/manu-gen/frontend/src/features/stations/components/StationTable.test.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationTable.test.tsx
@@ -24,13 +24,18 @@ function mockDeleteHook(overrides?: Partial<ReturnType<typeof useDeleteStation>>
 }
 
 describe("StationTable", () => {
+  let onDeleteError: (message: string) => void;
+
   beforeEach(() => {
     vi.resetAllMocks();
+    onDeleteError = vi.fn<(message: string) => void>();
   });
 
   it("should render station names and locations", () => {
     mockDeleteHook();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
+    render(<StationTable stations={stations} onDeleteError={onDeleteError} />, {
+      wrapper: createWrapper(),
+    });
 
     expect(screen.getByText("Polishing")).toBeInTheDocument();
     expect(screen.getByText("Floor 2")).toBeInTheDocument();
@@ -39,21 +44,27 @@ describe("StationTable", () => {
 
   it("should show camera badge when eye is assigned", () => {
     mockDeleteHook();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
+    render(<StationTable stations={stations} onDeleteError={onDeleteError} />, {
+      wrapper: createWrapper(),
+    });
 
     expect(screen.getByText("eye-1")).toBeInTheDocument();
   });
 
   it("should show 'No camera' when eye is not assigned", () => {
     mockDeleteHook();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
+    render(<StationTable stations={stations} onDeleteError={onDeleteError} />, {
+      wrapper: createWrapper(),
+    });
 
     expect(screen.getByText("No camera")).toBeInTheDocument();
   });
 
   it("should render slot capacity from station data", () => {
     mockDeleteHook();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
+    render(<StationTable stations={stations} onDeleteError={onDeleteError} />, {
+      wrapper: createWrapper(),
+    });
 
     expect(screen.getByText("3 slots")).toBeInTheDocument();
     expect(screen.getByText("1 slot")).toBeInTheDocument();
@@ -64,7 +75,9 @@ describe("StationTable", () => {
     mockDeleteHook({ mutate });
 
     const user = userEvent.setup();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
+    render(<StationTable stations={stations} onDeleteError={onDeleteError} />, {
+      wrapper: createWrapper(),
+    });
 
     await user.click(
       screen.getByRole("button", { name: "Delete station Polishing" }),
@@ -80,7 +93,9 @@ describe("StationTable", () => {
     mockDeleteHook({ mutate });
 
     const user = userEvent.setup();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
+    render(<StationTable stations={stations} onDeleteError={onDeleteError} />, {
+      wrapper: createWrapper(),
+    });
 
     await user.click(
       screen.getByRole("button", { name: "Delete station Polishing" }),
@@ -92,27 +107,32 @@ describe("StationTable", () => {
 
   it("should show em dash for missing location", () => {
     mockDeleteHook();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
+    render(<StationTable stations={stations} onDeleteError={onDeleteError} />, {
+      wrapper: createWrapper(),
+    });
 
     expect(screen.getByText("\u2014")).toBeInTheDocument();
   });
 
-  it("should display error message when delete fails", async () => {
+  it("should call onDeleteError when delete fails without changing the actions column layout", async () => {
     const mutate = vi.fn().mockImplementation((_id, options) => {
       options.onError(new Error("Used in 1 pipeline step(s)"));
     });
     mockDeleteHook({ mutate });
 
     const user = userEvent.setup();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
+    render(<StationTable stations={stations} onDeleteError={onDeleteError} />, {
+      wrapper: createWrapper(),
+    });
 
     await user.click(
       screen.getByRole("button", { name: "Delete station Polishing" }),
     );
     await user.click(screen.getByRole("button", { name: "Confirm" }));
 
-    expect(screen.getByText("Used in 1 pipeline step(s)")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "OK" })).toBeInTheDocument();
+    expect(onDeleteError).toHaveBeenCalledWith("Used in 1 pipeline step(s)");
+    expect(screen.queryByText("Used in 1 pipeline step(s)")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete station Polishing" })).toBeInTheDocument();
   });
 
   it("should call onSelectStation when a row is clicked", async () => {
@@ -121,7 +141,11 @@ describe("StationTable", () => {
 
     const user = userEvent.setup();
     render(
-      <StationTable stations={stations} onSelectStation={onSelectStation} />,
+      <StationTable
+        stations={stations}
+        onDeleteError={onDeleteError}
+        onSelectStation={onSelectStation}
+      />,
       { wrapper: createWrapper() },
     );
 
@@ -130,22 +154,4 @@ describe("StationTable", () => {
     expect(onSelectStation).toHaveBeenCalledWith(stations[0]);
   });
 
-  it("should dismiss error when OK is clicked", async () => {
-    const mutate = vi.fn().mockImplementation((_id, options) => {
-      options.onError(new Error("Cannot delete"));
-    });
-    mockDeleteHook({ mutate });
-
-    const user = userEvent.setup();
-    render(<StationTable stations={stations} />, { wrapper: createWrapper() });
-
-    await user.click(
-      screen.getByRole("button", { name: "Delete station Polishing" }),
-    );
-    await user.click(screen.getByRole("button", { name: "Confirm" }));
-    await user.click(screen.getByRole("button", { name: "OK" }));
-
-    expect(screen.queryByText("Cannot delete")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Delete station Polishing" })).toBeInTheDocument();
-  });
 });

--- a/manu-gen/frontend/src/features/stations/components/StationTable.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationTable.tsx
@@ -6,6 +6,8 @@ import styles from "./StationTable.module.css";
 
 interface StationTableProps {
   stations: Station[];
+  /** Called when delete fails (e.g. 409 — station in use). Parent should show a banner, not inline in the row. */
+  onDeleteError: (message: string) => void;
   onSelectStation?: (station: Station) => void;
 }
 
@@ -37,20 +39,24 @@ function CameraBadge({ eyeId }: { eyeId: string | null }): React.JSX.Element {
   return <span className={styles.badgeNone}>No camera</span>;
 }
 
-function ActionsCell({ station }: { station: Station }): React.JSX.Element {
+function ActionsCell({
+  station,
+  onDeleteError,
+}: {
+  station: Station;
+  onDeleteError: (message: string) => void;
+}): React.JSX.Element {
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const deleteStation = useDeleteStation();
 
   function handleDelete(): void {
     if (!confirmDelete) {
-      setDeleteError(null);
       setConfirmDelete(true);
       return;
     }
     deleteStation.mutate(station.id, {
       onError: (err) => {
-        setDeleteError(err instanceof Error ? err.message : "Delete failed");
+        onDeleteError(err instanceof Error ? err.message : "Delete failed");
         setConfirmDelete(false);
       },
     });
@@ -69,27 +75,13 @@ function ActionsCell({ station }: { station: Station }): React.JSX.Element {
         </button>
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); setConfirmDelete(false); setDeleteError(null); }}
+          onClick={(e) => {
+            e.stopPropagation();
+            setConfirmDelete(false);
+          }}
           className={`${styles.btnGhost} ${styles.btnMuted}`}
         >
           Cancel
-        </button>
-      </div>
-    );
-  }
-
-  if (deleteError) {
-    return (
-      <div className={styles.actionsRow}>
-        <span className={styles.errorTruncate} title={deleteError}>
-          {deleteError}
-        </span>
-        <button
-          type="button"
-          onClick={(e) => { e.stopPropagation(); setDeleteError(null); }}
-          className={`${styles.btnGhost} ${styles.btnMuted}`}
-        >
-          OK
         </button>
       </div>
     );
@@ -112,7 +104,11 @@ function ActionsCell({ station }: { station: Station }): React.JSX.Element {
   );
 }
 
-export function StationTable({ stations, onSelectStation }: StationTableProps): React.JSX.Element {
+export function StationTable({
+  stations,
+  onDeleteError,
+  onSelectStation,
+}: StationTableProps): React.JSX.Element {
   const columns: Column<Station>[] = [
     {
       key: "name",
@@ -144,7 +140,7 @@ export function StationTable({ stations, onSelectStation }: StationTableProps): 
       key: "actions",
       header: "Actions",
       align: "right",
-      render: (station) => <ActionsCell station={station} />,
+      render: (station) => <ActionsCell station={station} onDeleteError={onDeleteError} />,
     },
   ];
 

--- a/manu-gen/frontend/src/features/stations/hooks/useAssignEye.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useAssignEye.ts
@@ -1,13 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../../../shared/api/client";
 import type { Station } from "../stations.types";
+import { stationSchema } from "../stations.api-schema";
 
 export function useAssignEye() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ stationId, eyeId }: { stationId: string; eyeId: string }) =>
-      apiClient.put<Station>(`/stations/${stationId}/eye`, { eyeId }),
+      apiClient.put<Station>(`/stations/${stationId}/eye`, { eyeId }, stationSchema),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["stations"] });
     },

--- a/manu-gen/frontend/src/features/stations/hooks/useCreateStation.test.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useCreateStation.test.ts
@@ -18,6 +18,7 @@ const sampleStation: Station = {
   name: "Polishing",
   location: "Floor 2",
   eyeId: null,
+  slotCapacity: 1,
 };
 
 describe("useCreateStation", () => {
@@ -38,7 +39,7 @@ describe("useCreateStation", () => {
 
     expect(apiClient.post).toHaveBeenCalledWith(
       "/stations",
-      { name: "Polishing", location: "Floor 2" },
+      expect.objectContaining({ name: "Polishing", location: "Floor 2" }),
       expect.anything(),
     );
   });

--- a/manu-gen/frontend/src/features/stations/hooks/useCreateStation.test.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useCreateStation.test.ts
@@ -39,7 +39,41 @@ describe("useCreateStation", () => {
 
     expect(apiClient.post).toHaveBeenCalledWith(
       "/stations",
-      expect.objectContaining({ name: "Polishing", location: "Floor 2" }),
+      { name: "Polishing", location: "Floor 2" },
+      expect.anything(),
+    );
+    expect(vi.mocked(apiClient.post).mock.calls[0][1]).not.toHaveProperty("cameraId");
+  });
+
+  it("should POST only station fields without slotCapacity when omitted", async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(sampleStation);
+
+    const { result } = renderHook(() => useCreateStation(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Polishing" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(apiClient.post).toHaveBeenCalledWith("/stations", { name: "Polishing" }, expect.anything());
+    expect(vi.mocked(apiClient.post).mock.calls[0][1]).not.toHaveProperty("cameraId");
+  });
+
+  it("should include slotCapacity in the JSON body when provided", async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(sampleStation);
+
+    const { result } = renderHook(() => useCreateStation(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ name: "Press", location: "North", slotCapacity: 8 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/stations",
+      { name: "Press", location: "North", slotCapacity: 8 },
       expect.anything(),
     );
   });

--- a/manu-gen/frontend/src/features/stations/hooks/useCreateStation.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useCreateStation.ts
@@ -1,15 +1,26 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../../../shared/api/client";
 import type { Station } from "../stations.types";
-import type { CreateStationFormValues } from "../stations.schema";
+import type { CreateStationRequestBody } from "../stations.schema";
 import { stationSchema } from "../stations.api-schema";
+
+function createStationJsonBody(data: CreateStationRequestBody): Record<string, unknown> {
+  const body: Record<string, unknown> = { name: data.name };
+  if (data.location !== undefined) {
+    body.location = data.location ?? "";
+  }
+  if (data.slotCapacity !== undefined) {
+    body.slotCapacity = data.slotCapacity;
+  }
+  return body;
+}
 
 export function useCreateStation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: CreateStationFormValues) =>
-      apiClient.post<Station>("/stations", data, stationSchema),
+    mutationFn: (data: CreateStationRequestBody) =>
+      apiClient.post<Station>("/stations", createStationJsonBody(data), stationSchema),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["stations"] });
     },

--- a/manu-gen/frontend/src/features/stations/hooks/useUnassignEye.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useUnassignEye.ts
@@ -1,13 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../../../shared/api/client";
 import type { Station } from "../stations.types";
+import { stationSchema } from "../stations.api-schema";
 
 export function useUnassignEye() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (stationId: string) =>
-      apiClient.delete<Station>(`/stations/${stationId}/eye`),
+      apiClient.delete<Station>(`/stations/${stationId}/eye`, stationSchema),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["stations"] });
     },

--- a/manu-gen/frontend/src/features/stations/hooks/useUpdateStation.ts
+++ b/manu-gen/frontend/src/features/stations/hooks/useUpdateStation.ts
@@ -7,16 +7,21 @@ export interface UpdateStationPayload {
   id: string;
   name: string;
   location?: string;
+  slotCapacity?: number;
 }
 
 export function useUpdateStation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, name, location }: UpdateStationPayload) =>
+    mutationFn: ({ id, name, location, slotCapacity }: UpdateStationPayload) =>
       apiClient.put<Station>(
         `/stations/${id}`,
-        { name, location: location ?? "" },
+        {
+          name,
+          location: location ?? "",
+          ...(slotCapacity !== undefined ? { slotCapacity } : {}),
+        },
         stationSchema,
       ),
     onSuccess: () => {

--- a/manu-gen/frontend/src/features/stations/slotCapacity.utils.test.ts
+++ b/manu-gen/frontend/src/features/stations/slotCapacity.utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { clampSlotCapacityForApi } from "./slotCapacity.utils";
+
+describe("clampSlotCapacityForApi", () => {
+  it("returns 1 for non-finite values", () => {
+    expect(clampSlotCapacityForApi(NaN)).toBe(1);
+    expect(clampSlotCapacityForApi(undefined)).toBe(1);
+    expect(clampSlotCapacityForApi("3")).toBe(1);
+  });
+
+  it("truncates and clamps to 1–15", () => {
+    expect(clampSlotCapacityForApi(3.7)).toBe(3);
+    expect(clampSlotCapacityForApi(0)).toBe(1);
+    expect(clampSlotCapacityForApi(99)).toBe(15);
+  });
+});

--- a/manu-gen/frontend/src/features/stations/slotCapacity.utils.ts
+++ b/manu-gen/frontend/src/features/stations/slotCapacity.utils.ts
@@ -1,0 +1,7 @@
+/** Coerce UI / JSON quirks (NaN, empty) to a valid API slot count in 1–15. */
+export function clampSlotCapacityForApi(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 1;
+  }
+  return Math.min(15, Math.max(1, Math.trunc(value)));
+}

--- a/manu-gen/frontend/src/features/stations/stations.api-schema.test.ts
+++ b/manu-gen/frontend/src/features/stations/stations.api-schema.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { stationSchema } from "./stations.api-schema";
+
+describe("stationSchema", () => {
+  it("defaults missing slotCapacity to 1 for older API payloads", () => {
+    const parsed = stationSchema.parse({
+      id: "station-1",
+      name: "A",
+      location: "",
+      eyeId: null,
+    });
+    expect(parsed.slotCapacity).toBe(1);
+  });
+
+  it("defaults null slotCapacity to 1", () => {
+    const parsed = stationSchema.parse({
+      id: "station-1",
+      name: "A",
+      location: "",
+      eyeId: null,
+      slotCapacity: null,
+    });
+    expect(parsed.slotCapacity).toBe(1);
+  });
+
+  it("accepts valid slotCapacity", () => {
+    const parsed = stationSchema.parse({
+      id: "station-1",
+      name: "A",
+      location: "",
+      eyeId: null,
+      slotCapacity: 12,
+    });
+    expect(parsed.slotCapacity).toBe(12);
+  });
+
+  it("clamps out-of-range slotCapacity from API to 1", () => {
+    const parsed = stationSchema.parse({
+      id: "station-1",
+      name: "A",
+      location: "",
+      eyeId: null,
+      slotCapacity: 99,
+    });
+    expect(parsed.slotCapacity).toBe(1);
+  });
+});

--- a/manu-gen/frontend/src/features/stations/stations.api-schema.ts
+++ b/manu-gen/frontend/src/features/stations/stations.api-schema.ts
@@ -1,11 +1,28 @@
 import { z } from "zod";
 
+/**
+ * Missing or non-finite slotCapacity defaults to 1 so a newer FE can run against an older API.
+ * Values outside 1–15 also fall back to 1 (lenient parse); the server remains authoritative on writes.
+ */
+const slotCapacityFromApi = z.preprocess((val) => {
+  if (val === undefined || val === null) {
+    return 1;
+  }
+  if (typeof val === "number" && Number.isFinite(val)) {
+    const n = Math.trunc(val);
+    if (n >= 1 && n <= 15) {
+      return n;
+    }
+  }
+  return 1;
+}, z.number().int().min(1).max(15));
+
 export const stationSchema = z.object({
   id: z.string(),
   name: z.string(),
   location: z.string(),
   eyeId: z.string().nullable(),
-  slotCapacity: z.number().int().min(1).max(15),
+  slotCapacity: slotCapacityFromApi,
 });
 
 export const stationListSchema = z.array(stationSchema);

--- a/manu-gen/frontend/src/features/stations/stations.api-schema.ts
+++ b/manu-gen/frontend/src/features/stations/stations.api-schema.ts
@@ -5,7 +5,7 @@ export const stationSchema = z.object({
   name: z.string(),
   location: z.string(),
   eyeId: z.string().nullable(),
-  slotCapacity: z.number().int().optional(),
+  slotCapacity: z.number().int().min(1).max(15),
 });
 
 export const stationListSchema = z.array(stationSchema);

--- a/manu-gen/frontend/src/features/stations/stations.schema.test.ts
+++ b/manu-gen/frontend/src/features/stations/stations.schema.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { createStationSchema } from "./stations.schema";
+
+describe("createStationSchema", () => {
+  it("rejects NaN slotCapacity", () => {
+    const result = createStationSchema.safeParse({
+      name: "Test",
+      slotCapacity: Number.NaN,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/manu-gen/frontend/src/features/stations/stations.schema.ts
+++ b/manu-gen/frontend/src/features/stations/stations.schema.ts
@@ -3,7 +3,13 @@ import { z } from "zod";
 export const createStationSchema = z.object({
   name: z.string().min(1, "Station name is required"),
   location: z.string().optional(),
-  slotCapacity: z.number().int().min(1).max(15, "Maximum 15 slots").optional(),
+  slotCapacity: z
+    .number({ error: () => ({ message: "Enter a number between 1 and 15" }) })
+    .finite("Enter a number between 1 and 15")
+    .int("Enter a number between 1 and 15")
+    .min(1, "Minimum 1 slot")
+    .max(15, "Maximum 15 slots")
+    .optional(),
   cameraId: z.string().optional(),
 });
 

--- a/manu-gen/frontend/src/features/stations/stations.schema.ts
+++ b/manu-gen/frontend/src/features/stations/stations.schema.ts
@@ -14,3 +14,6 @@ export const createStationSchema = z.object({
 });
 
 export type CreateStationFormValues = z.infer<typeof createStationSchema>;
+
+/** Payload for POST /stations — excludes `cameraId` (assign via PUT /stations/:id/eye). */
+export type CreateStationRequestBody = Pick<CreateStationFormValues, "name" | "location" | "slotCapacity">;

--- a/manu-gen/frontend/src/features/stations/stations.types.ts
+++ b/manu-gen/frontend/src/features/stations/stations.types.ts
@@ -3,5 +3,5 @@ export interface Station {
   name: string;
   location: string;
   eyeId: string | null;
-  slotCapacity?: number;
+  slotCapacity: number;
 }


### PR DESCRIPTION
## Summary
Adds persisted **concurrent slot capacity** (1–15, default 1) for stations across SQLite, API, and the stations UI, with clearer save/delete flows and a Docker-friendly HTTP bind so host tools (e.g. manu-eye) can reach the backend when containers publish ports.

## Changes
- **Database:** `slot_capacity` on `stations` (CREATE + additive `ALTER` with guarded migration and clearer failure if migration breaks).
- **API:** Zod validation for `slotCapacity` on create/update; controller and service tests extended.
- **Frontend:** Form field + preview/list capacity display; lenient API parse for older backends; `useCreateStation` POST body omits `cameraId` (assign via eye endpoints); `NewStationView` / `EditStationView` use explicit saving state and recovery copy when camera assign fails after create/update.
- **Delete UX:** Station delete errors (e.g. 409 in pipeline) surface as a **top** dismissible `role="alert"` banner instead of breaking the actions column.
- **Ops:** `HOST=0.0.0.0` in compose and Express listen so host port mapping works reliably (e.g. Colima).

## Test plan
- `cd manu-gen/backend && yarn typecheck && yarn test`
- `cd manu-gen/frontend && npx tsc --noEmit && yarn test`
- Manually: create/edit station with slot capacity; confirm list and preview; attempt delete on a station used in a pipeline and confirm top alert + dismiss; with compose up, `curl http://127.0.0.1:3000/health` from the host (restart Colima if the port forward is stale).

## Notes
- Live station occupancy vs capacity is **not** in this PR; preview and table dots reflect **configured** capacity only.

Made with [Cursor](https://cursor.com)