### PR TITLE
refactor(ui): shared DismissibleNoticeBanner for station errors

### DIFF
--- a/manu-gen/frontend/src/features/stations/components/StationList.module.css
+++ b/manu-gen/frontend/src/features/stations/components/StationList.module.css
@@ -81,56 +81,6 @@
   color: var(--text-muted);
 }
 
-/* Inline alert: same dismiss pattern as HintBanner (X), palette uses --alert (signal) per design tokens */
-.deleteAlert {
-  position: relative;
-  display: flex;
-  align-items: center;
-  border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--alert) 28%, var(--border));
-  background: var(--alert-light);
-  /* Equal vertical padding; extra horizontal end space for the absolute close control */
-  padding: var(--space-3) calc(var(--space-4) + var(--space-6)) var(--space-3) var(--space-4);
+.noticeAboveList {
   margin-bottom: var(--space-4);
-}
-
-.deleteAlertMessage {
-  margin: 0;
-  flex: 1;
-  min-width: 0;
-  font-family: var(--font-body);
-  font-size: var(--text-sm);
-  line-height: 1.5;
-  color: var(--alert-dark);
-}
-
-.deleteAlertClose {
-  position: absolute;
-  top: 50%;
-  right: var(--space-3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--space-6);
-  height: var(--space-6);
-  margin-top: 0;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: none;
-  padding: 0;
-  color: var(--text-muted);
-  cursor: pointer;
-  transform: translateY(-50%);
-  transition: color var(--duration-fast) var(--easing-default),
-    background-color var(--duration-fast) var(--easing-default);
-}
-
-.deleteAlertClose:hover {
-  color: var(--text);
-  background: var(--surface-2);
-}
-
-.deleteAlertClose:focus-visible {
-  outline: 2px solid var(--alert);
-  outline-offset: 2px;
 }

--- a/manu-gen/frontend/src/features/stations/components/StationList.tsx
+++ b/manu-gen/frontend/src/features/stations/components/StationList.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { PackageOpen, X } from "lucide-react";
+import { PackageOpen } from "lucide-react";
 import { useStations } from "../hooks/useStations";
+import { DismissibleNoticeBanner } from "../../../shared/components/DismissibleNoticeBanner";
 import { ListCard } from "../../../shared/components/ListCard";
 import { StationTable } from "./StationTable";
 import type { Station } from "../stations.types";
@@ -77,19 +78,14 @@ export function StationList({ onSelectStation }: StationListProps): React.JSX.El
   return (
     <>
       {deleteError !== null && deleteError !== "" && (
-        <div className={styles.deleteAlert} role="alert">
-          <p className={styles.deleteAlertMessage}>{deleteError}</p>
-          <button
-            type="button"
-            className={styles.deleteAlertClose}
-            aria-label="Dismiss notification"
-            onClick={() => {
-              setDeleteError(null);
-            }}
-          >
-            <X size={12} strokeWidth={1.5} aria-hidden />
-          </button>
-        </div>
+        <DismissibleNoticeBanner
+          className={styles.noticeAboveList}
+          message={deleteError}
+          variant="alert"
+          onDismiss={() => {
+            setDeleteError(null);
+          }}
+        />
       )}
       <ListCard
         title="All Stations"

--- a/manu-gen/frontend/src/shared/components/DismissibleNoticeBanner.module.css
+++ b/manu-gen/frontend/src/shared/components/DismissibleNoticeBanner.module.css
@@ -1,0 +1,75 @@
+.banner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-md);
+  padding: var(--space-3) calc(var(--space-4) + var(--space-6)) var(--space-3) var(--space-4);
+}
+
+.bannerAlert {
+  border: 1px solid color-mix(in srgb, var(--alert) 28%, var(--border));
+  background: var(--alert-light);
+}
+
+.bannerSuccess {
+  border: 1px solid color-mix(in srgb, var(--status-ok) 28%, var(--border));
+  background: var(--status-ok-bg);
+}
+
+.message {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.messageAlert {
+  color: var(--alert-dark);
+}
+
+.messageSuccess {
+  color: var(--status-ok);
+}
+
+.close {
+  position: absolute;
+  top: 50%;
+  right: var(--space-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--space-6);
+  height: var(--space-6);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  padding: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  transform: translateY(-50%);
+  transition: color var(--duration-fast) var(--easing-default),
+    background-color var(--duration-fast) var(--easing-default);
+}
+
+.close:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .close {
+    transition: none;
+  }
+}
+
+.bannerAlert .close:focus-visible {
+  outline: 2px solid var(--alert);
+  outline-offset: 2px;
+}
+
+.bannerSuccess .close:focus-visible {
+  outline: 2px solid var(--status-ok);
+  outline-offset: 2px;
+}

--- a/manu-gen/frontend/src/shared/components/DismissibleNoticeBanner.test.tsx
+++ b/manu-gen/frontend/src/shared/components/DismissibleNoticeBanner.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { DismissibleNoticeBanner } from "./DismissibleNoticeBanner";
+
+describe("DismissibleNoticeBanner", () => {
+  it("renders message and calls onDismiss when close is activated", async () => {
+    const onDismiss = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DismissibleNoticeBanner message="Something went wrong" onDismiss={onDismiss} variant="alert" />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong");
+    await user.click(screen.getByRole("button", { name: "Dismiss notification" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses role=status for success variant", () => {
+    render(
+      <DismissibleNoticeBanner message="Saved" onDismiss={vi.fn()} variant="success" dismissAriaLabel="Close" />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Saved");
+  });
+
+  it("uses custom dismiss aria-label", async () => {
+    const user = userEvent.setup();
+    render(
+      <DismissibleNoticeBanner
+        message="Hi"
+        onDismiss={vi.fn()}
+        dismissAriaLabel="Close banner"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Close banner" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Close banner" }));
+  });
+});

--- a/manu-gen/frontend/src/shared/components/DismissibleNoticeBanner.tsx
+++ b/manu-gen/frontend/src/shared/components/DismissibleNoticeBanner.tsx
@@ -1,0 +1,42 @@
+import { X } from "lucide-react";
+import styles from "./DismissibleNoticeBanner.module.css";
+
+export type DismissibleNoticeVariant = "alert" | "success";
+
+export interface DismissibleNoticeBannerProps {
+  message: string;
+  onDismiss: () => void;
+  /** `alert`: `role="alert"` for errors. `success`: `role="status"` with polite live region. */
+  variant?: DismissibleNoticeVariant;
+  /** Accessible label for the dismiss control (default: Dismiss notification). */
+  dismissAriaLabel?: string;
+  className?: string;
+}
+
+export function DismissibleNoticeBanner({
+  message,
+  onDismiss,
+  variant = "alert",
+  dismissAriaLabel = "Dismiss notification",
+  className,
+}: DismissibleNoticeBannerProps): React.JSX.Element {
+  const bannerClass =
+    variant === "success"
+      ? `${styles.banner} ${styles.bannerSuccess}`
+      : `${styles.banner} ${styles.bannerAlert}`;
+  const messageClass =
+    variant === "success" ? `${styles.message} ${styles.messageSuccess}` : `${styles.message} ${styles.messageAlert}`;
+
+  return (
+    <div
+      className={[bannerClass, className].filter(Boolean).join(" ")}
+      role={variant === "success" ? "status" : "alert"}
+      aria-live={variant === "success" ? "polite" : undefined}
+    >
+      <p className={messageClass}>{message}</p>
+      <button type="button" className={styles.close} aria-label={dismissAriaLabel} onClick={onDismiss}>
+        <X size={12} strokeWidth={1.5} aria-hidden />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Extracts the stations delete-error **top banner** into a shared `DismissibleNoticeBanner` so the same pattern can be reused elsewhere without duplicating markup or tokens.

## Changes
- New `shared/components/DismissibleNoticeBanner` (+ CSS module + tests): **alert** variant (`role="alert"`, `--alert*` tokens) and **success** variant (`role="status"`, `aria-live="polite"`, `--status-ok*` tokens) for future use.
- Close control: `prefers-reduced-motion` disables transition on the dismiss button.
- `StationList` consumes the shared component; list spacing stays in `StationList.module.css` (`.noticeAboveList`).

## Test plan
- `cd manu-gen/frontend && npx tsc --noEmit && yarn test`

## Notes
- Does **not** add timed auto-dismiss; errors stay visible until dismissed (clearer for 409-style copy). A future enhancement can wrap this or add an optional auto-dismiss prop.
- Closes #21 — the original problem (inline / truncated delete errors) is addressed; the shared component matches the agreed direction (dismissible notice, token-aligned variants) without a separate toast stack.

Closes #21

Made with [Cursor](https://cursor.com)